### PR TITLE
CallSkill SpawnのCount引数に大きな値を入れるとクラッシュする (#102)

### DIFF
--- a/data/enemy/functions/spawn/.mcfunction
+++ b/data/enemy/functions/spawn/.mcfunction
@@ -17,6 +17,6 @@ summon spawner_minecart ~ ~500 ~ {Tags:[OneTimeSpawner],SpawnCount:1s,SpawnRange
 execute positioned ~ ~500 ~ as @e[type=spawner_minecart,distance=..0.01] if data entity @s SpawnData.Passengers[{id:"tusb_mob:creation"}] positioned ~ ~-500 ~ run function enemy:spawn/set_spawner/
 ### Count設定
 execute if data entity @s ArmorItems[3].tag.Count positioned ~ ~500 ~ run data modify entity @e[type=spawner_minecart,limit=1,distance=..0.01] SpawnCount set from entity @s ArmorItems[3].tag.Count
-execute if data entity @s ArmorItems[3].tag.Count run function enemy:spawn/count
+execute if data entity @s ArmorItems[3].tag.Count run function enemy:spawn/set_spawner/count/
 
 kill @s

--- a/data/enemy/functions/spawn/count.mcfunction
+++ b/data/enemy/functions/spawn/count.mcfunction
@@ -1,5 +1,0 @@
-
-data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList[]
-
-execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
-execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/count

--- a/data/enemy/functions/spawn/set_spawner/count/.mcfunction
+++ b/data/enemy/functions/spawn/set_spawner/count/.mcfunction
@@ -1,0 +1,4 @@
+
+data modify storage tusb_mob: DelayedData set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList
+
+function enemy:spawn/set_spawner/count/loop

--- a/data/enemy/functions/spawn/set_spawner/count/loop.mcfunction
+++ b/data/enemy/functions/spawn/set_spawner/count/loop.mcfunction
@@ -1,0 +1,5 @@
+
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList append from storage tusb_mob: DelayedData
+
+execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
+execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/set_spawner/count/loop


### PR DESCRIPTION
Countを20以上にするとクラッシュする。  
DelayedDataListをCount分複製するときに、DelayedDataListからコピーしていたため、指数関数的にDelayedDataListのデータ数が増えていた。