### PR TITLE
Countが2以上のときにステータスが引き継がれないバグを修正

### DIFF
--- a/data/enemy/functions/spawn/set_spawner/count/.mcfunction
+++ b/data/enemy/functions/spawn/set_spawner/count/.mcfunction
@@ -1,4 +1,5 @@
 
 data modify storage tusb_mob: DelayedData set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList
 
-function enemy:spawn/set_spawner/count/loop
+execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
+execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/set_spawner/count/loop

--- a/data/enemy/functions/spawn/set_spawner/count/loop.mcfunction
+++ b/data/enemy/functions/spawn/set_spawner/count/loop.mcfunction
@@ -1,5 +1,5 @@
 
-data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList append from storage tusb_mob: DelayedData
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList append from storage tusb_mob: DelayedData[]
 
 execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
 execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/set_spawner/count/loop


### PR DESCRIPTION
CallSkill SpawnのCount引数に大きな値を入れるとクラッシュする ([#102](https://github.com/TUSB/TheUnusualSkyBlock/issues/102)) #103  
の修正。

主に、Countが2以上のときのみloop処理を実行するようになったのと、ちゃんとcompound型のListにcompound型をappendするようにした