### PR TITLE
データパックのリビジョン情報をStorage内に格納し出力するよう変更

### DIFF
--- a/data/main/functions/load_once.mcfunction
+++ b/data/main/functions/load_once.mcfunction
@@ -6,6 +6,9 @@
 # リリースする際は必ずオフにすること
 data modify storage main: debug set value 1b
 
+### Git情報(値はデバッグサーバ側で置き換え文字置換される)
+data modify storage main: Repository set value {CommitHash:"__GIT_COMMIT_HASH__",CommitHashShort:"__GIT_COMMIT_HASH_SHORT__",Branch:"__GIT_BRANCH__"}
+
 ###バージョン
 function settings:version_update/check/
 

--- a/data/settings/functions/version_update/check/.mcfunction
+++ b/data/settings/functions/version_update/check/.mcfunction
@@ -7,7 +7,8 @@ data modify storage v13alpha: UpdatingVersion set value {Major:2,Minor:1}
 
 tellraw @a {"translate":"[System] 以前のVersion: v13.%1$s.%2$s.α   現在のVersion: v13.%3$s.%4$s.α","color":"green","with":[{"storage":"v13alpha:","nbt":"Version.Major"},{"storage":"v13alpha:","nbt":"Version.Minor"},{"storage":"v13alpha:","nbt":"UpdatingVersion.Major"},{"storage":"v13alpha:","nbt":"UpdatingVersion.Minor"}]}
 
-execute if data storage main: {debug:1b} run tellraw @a [{"text":"[Debug] 現在適用されているデータパックVersion "},{"text":"__COMMIT_HASH__","color":"green","underlined":true,"clickEvent":{"action":"open_url","value":"https://github.com/TUSB/TheUnusualSkyBlock/commit/__COMMIT_HASH__"}}]
+# データパックRevision情報出力(デバッグ)
+execute if data storage main: {debug:1b} run tellraw @a [{"text":"[Debug] データパックRevision:"},{"translate":" (%1$s / %2$s)","color":"yellow","underlined":true,"bold":true,"with":[{"storage":"main:","nbt":"Repository.CommitHashShort"},{"storage":"main:","nbt":"Repository.Branch"}]}]
 
 #メジャーバージョンチェック
 function settings:version_update/check/major


### PR DESCRIPTION
コミット情報をストレージ格納するように変更  
サーバ側は data/main/functions/load_once.mcfunction の内容を置換ファイル対象にするだけでどこでもこの値を使うことができる(対象文字列がある場所を管理と検索しなくていいから楽)


結果表示イメージ:  
https://github.com/TUSB/TheUnusualSkyBlock/commit/8888282d4298d160ca5ac3314c015b179b67e372 
なら下のように表示される。

![2023-11-22_02 16 39](https://github.com/TUSB/TheUnusualSkyBlock/assets/12383342/9e160202-9d79-44e5-9fe9-ce270ac749f8)


---


ついでに質問:
`"clickEvent":{"action":"open_url","value":"https://github.com/TUSB/TheUnusualSkyBlock/commit/%1$s"}` みたいなことをして
クリックイベントのURLにストレージの値を使うようなことってできる?