### PR TITLE
Feature/#373/エンティティ削除系処理

### DIFF
--- a/data/entity/function/check_freeze.mcfunction
+++ b/data/entity/function/check_freeze.mcfunction
@@ -1,0 +1,14 @@
+#> entity:check_freeze
+##############################
+### 投射物等が凍結しているかチェック
+##############################
+
+###PortalCooldownの値が1秒前と変化していなければ、凍結していると判断して消す
+execute store result score _ ProjectileLife run data get entity @s PortalCooldown
+
+execute if score @s ProjectileLife = _ ProjectileLife if entity @s[tag=HasSkillDisplay] on passengers run kill @s[tag=SkillDisplay]
+###PortalCooldownを消費しきったときにのみ各種処理を実行する
+execute if score @s ProjectileLife = _ ProjectileLife unless score _ ProjectileLife matches 0 run tag @s add Garbage
+execute if score @s ProjectileLife = _ ProjectileLife if score _ ProjectileLife matches 0 run function entity:cooldown
+
+scoreboard players operation @s ProjectileLife = _ ProjectileLife

--- a/data/entity/function/cooldown.mcfunction
+++ b/data/entity/function/cooldown.mcfunction
@@ -1,0 +1,19 @@
+#> entity:cooldown
+##############################
+### PortalCooldown0トリガー
+##############################
+
+###死亡処理
+tag @s add Garbage
+
+###CallOnTimeOut
+execute if entity @s[tag=CallOnTimeOut] run function enemy:ai/call/trigger/time
+
+###ダークスワンプ処理
+execute if entity @s[tag=DarkSwamp] run function skill:act/black_mage/dark_swamp/tick
+
+###ブラストスパーク炸裂
+execute if entity @s[tag=BlastSpark] run function skill:act/hunter/blast_spark/explode
+
+###ワイルドフレア拡散処理
+execute if entity @s[tag=WildFlareSeed] run function skill:act/hunter/wild_flare/explode

--- a/data/entity/function/garbage_collection.mcfunction
+++ b/data/entity/function/garbage_collection.mcfunction
@@ -1,0 +1,14 @@
+#> entity:garbage_collection
+##############################
+### エンティティ削除
+##############################
+
+execute if entity @s[tag=CallOnDeath] at @s run function enemy:ai/call/trigger/death
+# CallOnDeathで復活するならば削除処理は中止
+execute if entity @s[tag=!Garbage] run return fail
+
+execute if entity @s[tag=Parent] run function entity:kill_child
+execute if entity @s[tag=LifeScouter] on passengers if entity @s[tag=LifeScouterText] run kill @s
+data merge entity @s {Health:0f,Size:0,DeathTime:19s,HandItems:[{},{}],ArmorItems:[{},{},{},{}],Owner:[I;0,0,0,0]}
+data remove entity @s CustomName
+kill @s

--- a/data/entity/function/one_second.mcfunction
+++ b/data/entity/function/one_second.mcfunction
@@ -2,3 +2,6 @@
 # -> 10秒処理
 ## 使用するときにコメントアウトを外してください。
 # execute if score $Seconds Count matches 0 run function entity:ten_seconds
+
+### 停止飛翔物削除
+execute as @e[tag=TickingRequired] at @s run function entity:check_freeze

--- a/data/entity/function/tick.mcfunction
+++ b/data/entity/function/tick.mcfunction
@@ -6,5 +6,8 @@
 ### エンティティ初期化
 execute as @e[tag=!Initialized] at @s run function entity:initialize_entity
 
+### エンティティPortalCooldownチェック
+execute as @e[tag=CooldownRequired,nbt={PortalCooldown:0}] at @s run function entity:cooldown
+
 ### エンティティ削除 - 最後に実行
 execute as @e[tag=Garbage] run function entity:garbage_collection

--- a/data/entity/function/tick.mcfunction
+++ b/data/entity/function/tick.mcfunction
@@ -1,7 +1,7 @@
 #> entity:tick
 # -> 1秒処理
 ## 使用するときにコメントアウトを外してください。
-# execute if score $Ticks Count matches 0 run function entity:one_second
+execute if score $Ticks Count matches 0 run function entity:one_second
 
 ### エンティティ初期化
 execute as @e[tag=!Initialized] at @s run function entity:initialize_entity

--- a/data/entity/function/tick.mcfunction
+++ b/data/entity/function/tick.mcfunction
@@ -5,3 +5,6 @@
 
 ### エンティティ初期化
 execute as @e[tag=!Initialized] at @s run function entity:initialize_entity
+
+### エンティティ削除 - 最後に実行
+execute as @e[tag=Garbage] run function entity:garbage_collection


### PR DESCRIPTION
Close #373 

エンティティの削除に関する処理です。

* `Garbage`
	エンティティを削除する際のタグです。
	TUSBにおいての死亡はすべてこのタグで処理されます。
	CallOnDeathにてGarbageが取り消されたとき用にreturnで中断するようにしました。
* `CooldownRequired`
	NBT`PortalCooldown`の値を毎tick監視し続けて、0になったときに削除されます。
	削除時の処理の先は未実装ばかりです。
* `TickingRequired`
	エンティティがtickできる範囲から出た時、`PortalCooldown`の値が変わらなくなるため、毎秒監視して変化がなかった時に削除されます。
	演算距離を小さくすると検証しやすいです。