### PR TITLE
Feature/#378/playerの各種トリガー

### DIFF
--- a/data/makeup/function/player/trigger/using/shield.mcfunction
+++ b/data/makeup/function/player/trigger/using/shield.mcfunction
@@ -1,0 +1,2 @@
+playsound item.shield.block player @a[distance=..16] ~ ~ ~ 1 1
+particle crit ~ ~ ~ 0 0 0 0.1 3 force

--- a/data/player/advancement/trigger/death.json
+++ b/data/player/advancement/trigger/death.json
@@ -1,0 +1,83 @@
+{
+  "criteria": {
+    "death": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "nbt": "{Health:0f}"
+            }
+          },
+          {
+            "condition": "minecraft:entity_scores",
+            "entity": "this",
+            "scores": {
+              "Deaths": {
+                "min": 1,
+                "max": 2147483647
+              }
+            }
+          }
+        ]
+      }
+    },
+    "void_death": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:location_check",
+                "predicate": {
+                  "position": {
+                    "y": {
+                      "min": -500,
+                      "max": -64
+                    }
+                  }
+                }
+              },
+              {
+                "condition": "minecraft:location_check",
+                "predicate": {
+                  "dimension": "area:void"
+                }
+              }
+            ]
+          },
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "nbt": "{Health:0f}"
+            }
+          },
+          {
+            "condition": "minecraft:entity_scores",
+            "entity": "this",
+            "scores": {
+              "Deaths": {
+                "min": 1,
+                "max": 2147483647
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "death",
+      "void_death"
+    ]
+  ],
+  "rewards": {
+    "function": "player:trigger/death"
+  }
+}

--- a/data/player/advancement/trigger/slept_in_bed.json
+++ b/data/player/advancement/trigger/slept_in_bed.json
@@ -1,0 +1,10 @@
+{
+  "criteria": {
+      "slept_in_bed": {
+          "trigger": "minecraft:slept_in_bed"
+      }
+  },
+  "rewards": {
+      "function": "player:trigger/slept_in_bed/"
+  }
+}

--- a/data/player/advancement/trigger/use/ender_pearl.json
+++ b/data/player/advancement/trigger/use/ender_pearl.json
@@ -1,0 +1,34 @@
+{
+  "criteria": {
+    "teleport": {
+      "trigger": "entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": 5.0,
+          "type": {
+            "tags": [
+              {
+                "id": "player:fall",
+                "expected": true
+              }
+            ]
+          }
+        },
+        "player": [
+          {
+            "condition": "entity_scores",
+            "entity": "this",
+            "scores": {
+              "UseEnderPearl": {
+                "min": 1
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "player:trigger/use/ender_pearl"
+  }
+}

--- a/data/player/advancement/trigger/use/shield.json
+++ b/data/player/advancement/trigger/use/shield.json
@@ -1,0 +1,477 @@
+{
+  "criteria": {
+    "block": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "blocked": true
+        }
+      }
+    },
+    "4_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 0.0,
+            "max": 4.0
+          }
+        }
+      }
+    },
+    "8_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 4.0,
+            "max": 8.0
+          }
+        }
+      }
+    },
+    "12_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 8.0,
+            "max": 12.0
+          }
+        }
+      }
+    },
+    "16_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 12.0,
+            "max": 16.0
+          }
+        }
+      }
+    },
+    "20_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 16.0,
+            "max": 20.0
+          }
+        }
+      }
+    },
+    "24_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 20.0,
+            "max": 24.0
+          }
+        }
+      }
+    },
+    "28_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 24.0,
+            "max": 28.0
+          }
+        }
+      }
+    },
+    "32_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 28.0,
+            "max": 32.0
+          }
+        }
+      }
+    },
+    "36_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 32.0,
+            "max": 36.0
+          }
+        }
+      }
+    },
+    "40_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 36.0,
+            "max": 40.0
+          }
+        }
+      }
+    },
+    "44_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 40.0,
+            "max": 44.0
+          }
+        }
+      }
+    },
+    "48_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 44.0,
+            "max": 48.0
+          }
+        }
+      }
+    },
+    "52_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 48.0,
+            "max": 52.0
+          }
+        }
+      }
+    },
+    "56_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 52.0,
+            "max": 56.0
+          }
+        }
+      }
+    },
+    "60_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 56.0,
+            "max": 60.0
+          }
+        }
+      }
+    },
+    "64_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 60.0,
+            "max": 64.0
+          }
+        }
+      }
+    },
+    "68_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 64.0,
+            "max": 68.0
+          }
+        }
+      }
+    },
+    "72_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 68.0,
+            "max": 72.0
+          }
+        }
+      }
+    },
+    "76_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 72.0,
+            "max": 76.0
+          }
+        }
+      }
+    },
+    "80_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 76.0,
+            "max": 80.0
+          }
+        }
+      }
+    },
+    "84_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 80.0,
+            "max": 84.0
+          }
+        }
+      }
+    },
+    "88_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 84.0,
+            "max": 88.0
+          }
+        }
+      }
+    },
+    "92_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 88.0,
+            "max": 92.0
+          }
+        }
+      }
+    },
+    "96_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 92.0,
+            "max": 96.0
+          }
+        }
+      }
+    },
+    "100_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 96.0,
+            "max": 100.0
+          }
+        }
+      }
+    },
+    "104_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 100.0,
+            "max": 104.0
+          }
+        }
+      }
+    },
+    "108_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 104.0,
+            "max": 108.0
+          }
+        }
+      }
+    },
+    "112_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 108.0,
+            "max": 112.0
+          }
+        }
+      }
+    },
+    "116_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 112.0,
+            "max": 116.0
+          }
+        }
+      }
+    },
+    "120_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 116.0,
+            "max": 120.0
+          }
+        }
+      }
+    },
+    "124_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 120.0,
+            "max": 124.0
+          }
+        }
+      }
+    },
+    "128_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 124.0,
+            "max": 128.0
+          }
+        }
+      }
+    },
+    "132_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 128.0,
+            "max": 132.0
+          }
+        }
+      }
+    },
+    "136_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 132.0,
+            "max": 136.0
+          }
+        }
+      }
+    },
+    "140_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 136.0,
+            "max": 140.0
+          }
+        }
+      }
+    },
+    "144_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 140.0,
+            "max": 144.0
+          }
+        }
+      }
+    },
+    "148_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 144.0,
+            "max": 148.0
+          }
+        }
+      }
+    },
+    "150_damage_taken": {
+      "trigger": "minecraft:entity_hurt_player",
+      "conditions": {
+        "damage": {
+          "dealt": {
+            "min": 148.0
+          }
+        }
+      }
+    }
+  },
+  "requirements": [
+    [
+      "block"
+    ],
+    [
+      "4_damage_taken",
+      "8_damage_taken",
+      "12_damage_taken",
+      "16_damage_taken",
+      "20_damage_taken",
+      "24_damage_taken",
+      "28_damage_taken",
+      "32_damage_taken",
+      "36_damage_taken",
+      "40_damage_taken",
+      "44_damage_taken",
+      "48_damage_taken",
+      "52_damage_taken",
+      "56_damage_taken",
+      "60_damage_taken",
+      "64_damage_taken",
+      "68_damage_taken",
+      "72_damage_taken",
+      "76_damage_taken",
+      "80_damage_taken",
+      "84_damage_taken",
+      "88_damage_taken",
+      "92_damage_taken",
+      "96_damage_taken",
+      "100_damage_taken",
+      "104_damage_taken",
+      "108_damage_taken",
+      "112_damage_taken",
+      "116_damage_taken",
+      "120_damage_taken",
+      "124_damage_taken",
+      "128_damage_taken",
+      "132_damage_taken",
+      "136_damage_taken",
+      "140_damage_taken",
+      "144_damage_taken",
+      "148_damage_taken",
+      "150_damage_taken"
+    ]
+  ],
+  "rewards": {
+    "function": "player:trigger/use/shield"
+  }
+}

--- a/data/player/advancement/trigger/using/shield.json
+++ b/data/player/advancement/trigger/using/shield.json
@@ -1,0 +1,17 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:using_item",
+      "conditions": {
+        "item": {
+          "items": [
+            "minecraft:shield"
+          ]
+        }
+      }
+    }
+  },
+  "rewards": {
+    "function": "player:trigger/using/shield/"
+  }
+}

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -18,3 +18,5 @@ execute if entity @s[scores={Talk=1..}] run function player:trigger/talk/
 execute if entity @s[scores={Trade=1..}] run function player:trigger/trade/
 execute if entity @s[scores={FoodLevel=1..}] run function player:trigger/food
 execute if entity @s[scores={kill=1..}] run function player:trigger/kill
+# ネザースター取得
+execute if entity @s[nbt={Inventory:[{id:"minecraft:nether_star"}]}] run function player:trigger/nether_star

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -14,3 +14,4 @@ execute if entity @s[scores={SneakTime=1..}] run function player:trigger/sneak
 execute if entity @s[scores={SneakFrequency=1..}] run function player:trigger/sneak_frequency
 execute if entity @s[scores={DamageTaken=0..}] run function player:trigger/damage_taken
 execute if entity @s[scores={Jump=1..}] run function player:trigger/jump
+execute if entity @s[scores={Talk=1..}] run function player:trigger/talk/

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -7,3 +7,4 @@
 execute if entity @s[scores={UseBow=1..}] run function player:trigger/use/bow
 execute if entity @s[scores={UseCrossbow=1..}] run function player:trigger/use/crossbow
 execute if entity @s[scores={UseTrident=1..}] run function player:trigger/use/trident
+execute if entity @s[scores={UseCarrotStick=1..}] run function player:trigger/use/carrot_on_a_stick

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -2,3 +2,6 @@
 # -> 1秒処理
 ## 使用するときにコメントアウトを外してください。
 # execute if score $Ticks Count matches 0 run function player:one_second
+
+### トリガー
+execute if entity @s[scores={UseBow=1..}] run function player:trigger/use/bow

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -6,3 +6,4 @@
 ### トリガー
 execute if entity @s[scores={UseBow=1..}] run function player:trigger/use/bow
 execute if entity @s[scores={UseCrossbow=1..}] run function player:trigger/use/crossbow
+execute if entity @s[scores={UseTrident=1..}] run function player:trigger/use/trident

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -8,3 +8,4 @@ execute if entity @s[scores={UseBow=1..}] run function player:trigger/use/bow
 execute if entity @s[scores={UseCrossbow=1..}] run function player:trigger/use/crossbow
 execute if entity @s[scores={UseTrident=1..}] run function player:trigger/use/trident
 execute if entity @s[scores={UseCarrotStick=1..}] run function player:trigger/use/carrot_on_a_stick
+# execute if entity @s[scores={UseFungusStick=1..}] run function player:trigger/use/warped_fungus_on_a_stick

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -15,3 +15,4 @@ execute if entity @s[scores={SneakFrequency=1..}] run function player:trigger/sn
 execute if entity @s[scores={DamageTaken=0..}] run function player:trigger/damage_taken
 execute if entity @s[scores={Jump=1..}] run function player:trigger/jump
 execute if entity @s[scores={Talk=1..}] run function player:trigger/talk/
+execute if entity @s[scores={Trade=1..}] run function player:trigger/trade/

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -17,3 +17,4 @@ execute if entity @s[scores={Jump=1..}] run function player:trigger/jump
 execute if entity @s[scores={Talk=1..}] run function player:trigger/talk/
 execute if entity @s[scores={Trade=1..}] run function player:trigger/trade/
 execute if entity @s[scores={FoodLevel=1..}] run function player:trigger/food
+execute if entity @s[scores={kill=1..}] run function player:trigger/kill

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -9,3 +9,4 @@ execute if entity @s[scores={UseCrossbow=1..}] run function player:trigger/use/c
 execute if entity @s[scores={UseTrident=1..}] run function player:trigger/use/trident
 execute if entity @s[scores={UseCarrotStick=1..}] run function player:trigger/use/carrot_on_a_stick
 # execute if entity @s[scores={UseFungusStick=1..}] run function player:trigger/use/warped_fungus_on_a_stick
+execute if entity @s[scores={UseMagmaCubeEgg=1..}] run function player:trigger/use/magma_cube_spawn_egg

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -13,3 +13,4 @@ execute if entity @s[scores={UseMagmaCubeEgg=1..}] run function player:trigger/u
 execute if entity @s[scores={SneakTime=1..}] run function player:trigger/sneak
 execute if entity @s[scores={SneakFrequency=1..}] run function player:trigger/sneak_frequency
 execute if entity @s[scores={DamageTaken=0..}] run function player:trigger/damage_taken
+execute if entity @s[scores={Jump=1..}] run function player:trigger/jump

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -5,3 +5,4 @@
 
 ### トリガー
 execute if entity @s[scores={UseBow=1..}] run function player:trigger/use/bow
+execute if entity @s[scores={UseCrossbow=1..}] run function player:trigger/use/crossbow

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -12,3 +12,4 @@ execute if entity @s[scores={UseCarrotStick=1..}] run function player:trigger/us
 execute if entity @s[scores={UseMagmaCubeEgg=1..}] run function player:trigger/use/magma_cube_spawn_egg
 execute if entity @s[scores={SneakTime=1..}] run function player:trigger/sneak
 execute if entity @s[scores={SneakFrequency=1..}] run function player:trigger/sneak_frequency
+execute if entity @s[scores={DamageTaken=0..}] run function player:trigger/damage_taken

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -10,3 +10,5 @@ execute if entity @s[scores={UseTrident=1..}] run function player:trigger/use/tr
 execute if entity @s[scores={UseCarrotStick=1..}] run function player:trigger/use/carrot_on_a_stick
 # execute if entity @s[scores={UseFungusStick=1..}] run function player:trigger/use/warped_fungus_on_a_stick
 execute if entity @s[scores={UseMagmaCubeEgg=1..}] run function player:trigger/use/magma_cube_spawn_egg
+execute if entity @s[scores={SneakTime=1..}] run function player:trigger/sneak
+execute if entity @s[scores={SneakFrequency=1..}] run function player:trigger/sneak_frequency

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -16,3 +16,4 @@ execute if entity @s[scores={DamageTaken=0..}] run function player:trigger/damag
 execute if entity @s[scores={Jump=1..}] run function player:trigger/jump
 execute if entity @s[scores={Talk=1..}] run function player:trigger/talk/
 execute if entity @s[scores={Trade=1..}] run function player:trigger/trade/
+execute if entity @s[scores={FoodLevel=1..}] run function player:trigger/food

--- a/data/player/function/trigger/damage_taken.mcfunction
+++ b/data/player/function/trigger/damage_taken.mcfunction
@@ -1,0 +1,14 @@
+
+### 被ダメージトリガー
+
+## トント 被ダメージ処理
+execute if score @s TntCount matches 0.. run function effects:tnt/check
+
+### 剣士＜リアクティブヒール＞発動
+execute if score @s ReactiveLevel matches 1.. run function skill:act/knight/reactive_heal/trigger/damage_taken
+
+### 剣士＜タクティカルヒール＞発動
+execute if score @s DamageTaken matches 120.. if score @s TacticalHeal matches 0.. run function skill:act/knight/tactical_heal/react
+
+# トリガーリセット
+scoreboard players reset @s DamageTaken

--- a/data/player/function/trigger/damage_taken.mcfunction
+++ b/data/player/function/trigger/damage_taken.mcfunction
@@ -1,4 +1,4 @@
-
+#> player:trigger/damage_taken
 ### 被ダメージトリガー
 
 ## トント 被ダメージ処理

--- a/data/player/function/trigger/death.mcfunction
+++ b/data/player/function/trigger/death.mcfunction
@@ -1,0 +1,41 @@
+#> player:trigger/death
+### 死亡時処理
+
+# 死亡ディメンション記録
+function #oh_my_dat:please
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathDimension set from entity @s Dimension
+
+# TUSBv13α2 チュートリアル中の死亡処理
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].tutorial_alpha run function tutorial_alpha:system/respawn
+
+#奈落死亡処理
+execute if entity @s[advancements={player:trigger/death={void_death=true}}] run function player:trigger/void_death/
+
+# レイズ処理
+tag @s[tag=Reraise] add Raise
+tag @s[tag=Reraise] remove Reraise
+execute if entity @s[tag=Raise] run function skill:act/white_mage/araise/raise
+
+# サヨナラ処理
+execute if score @s SayonaraLevel matches 1.. run function skill:act/ninja/sayonara/trigger/death
+
+#トグルスキル解除
+execute if entity @s[tag=!Raise] run function skill:toggle_reset
+
+# アイテムドロップ処理
+function player:death_item_drop/
+
+# 特殊床
+execute if block ~ ~-2 ~ minecraft:nether_wart_block if entity @s[nbt={OnGround:true}] run tellraw @a [{"translate":"「うおーっ！！」%1$sは  さけび  ごえを  あげ、さんを  だす  にくいゆかへ   ホップ・ステップ・ジャンプ．．．かーるいす！！\n%1$sは  とけ、ゆかと  どうか  してしまった。","with":[{"selector":"@s"}]}]
+
+#各種デバフ解除
+execute if score @s FreezeTimer matches 0.. run function effects:freeze/cure
+function skill:act/white_mage/clear/cure/level4
+
+## 死亡トリガーリセット
+execute store result score @s Hunger run data get entity @s foodLevel
+scoreboard players reset @s Deaths
+advancement revoke @s only player:trigger/death
+
+# TIPS表示
+function player:tips/show

--- a/data/player/function/trigger/food.mcfunction
+++ b/data/player/function/trigger/food.mcfunction
@@ -1,0 +1,13 @@
+#> player:trigger/food
+### 食事トリガー前処理
+
+scoreboard players operation @s LastFoodLevel -= @s FoodLevel
+scoreboard players set _ _ -1
+scoreboard players operation @s LastFoodLevel *= _ _
+
+### 狩人＜ワイルドヒーリング＞
+execute if score @s WildHealing matches 1..3 if score @s LastFoodLevel matches 1.. run function skill:act/hunter/wild_healing/trigger/eat
+
+### トリガーリセット
+scoreboard players operation @s LastFoodLevel = @s FoodLevel
+scoreboard players reset @s FoodLevel

--- a/data/player/function/trigger/jump.mcfunction
+++ b/data/player/function/trigger/jump.mcfunction
@@ -1,0 +1,8 @@
+#> player:trigger/jump
+### ジャンプ時処理
+
+### 跳躍攻撃処理
+execute if score @s Choyaku matches 1.. run function skill:act/ninja/choyaku/trigger/jump
+
+### ジャンプトリガーリセット
+scoreboard players reset @s Jump

--- a/data/player/function/trigger/kill.mcfunction
+++ b/data/player/function/trigger/kill.mcfunction
@@ -1,0 +1,9 @@
+#> player:trigger/kill
+scoreboard players set @s MP 0
+execute in area:skylands run spawnpoint @s -75 14 -619
+# data modify storage score_damage: Argument set value {Damage:99999,DamageType:["None"],BypassArmor:true,BypassResistance:true,DisableParticle:true,DeathCause:'[{"translate":"%1$sは祈りを捧げた。","with":[{"selector":"@s"}]}]'}
+# function score_damage:api/attack
+## ダメージシステムでkillする？
+kill @s
+scoreboard players enable @s kill
+scoreboard players set @s kill 0

--- a/data/player/function/trigger/nether_star.mcfunction
+++ b/data/player/function/trigger/nether_star.mcfunction
@@ -1,0 +1,4 @@
+#> player:trigger/nether_star
+# _ Expに取得したネザースターの数を記録して経験値取得処理を実行する。
+execute store result score _ Exp run clear @s nether_star
+function job:exp/get

--- a/data/player/function/trigger/projectile/load.mcfunction
+++ b/data/player/function/trigger/projectile/load.mcfunction
@@ -1,0 +1,14 @@
+#> player:trigger/projectile/load
+#装備を投射物のoh_my_datからロード
+function #oh_my_dat:please
+data modify storage item: SelectedItem set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SelectedItem
+data modify storage item: Equipments set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Equipments
+
+#ダメージをロード
+function skill:damage/load
+
+### スキル
+execute if entity @s[tag=Skill] run function player:trigger/projectile/skill
+
+### HasDisplayのアイテムディスプレイ削除
+execute if entity @s[tag=HasSkillDisplay] on passengers run kill @s[tag=SkillDisplay]

--- a/data/player/function/trigger/projectile/save.mcfunction
+++ b/data/player/function/trigger/projectile/save.mcfunction
@@ -1,0 +1,11 @@
+#> player:trigger/projectile/save
+#ダメージと装備を保存
+function #oh_my_dat:please
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SelectedItem set from storage item: SelectedItem
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Equipments set from storage item: Equipments
+
+#潜在能力 - 属性攻撃増加
+scoreboard players operation $ElementDamageAdd ElementDamageAdd = @a[distance=0] ElementDamageAdd
+
+#ダメージを保存
+function skill:damage/save

--- a/data/player/function/trigger/projectile/skill.mcfunction
+++ b/data/player/function/trigger/projectile/skill.mcfunction
@@ -1,0 +1,15 @@
+#> player:trigger/projectile/skill
+#狩人
+execute if entity @s[tag=ChainArrow] run function skill:act/hunter/chain_arrow/hit
+execute if entity @s[tag=StakesSucceeded] run function makeup:skill/act/hunter/stakes_fire/hit
+execute if entity @s[tag=BlastSpark] run function skill:act/hunter/blast_spark/hit
+#忍者
+execute if entity @s[tag=Shuriken] run function makeup:skill/act/ninja/shuriken/hit
+#召喚士
+execute if entity @s[tag=PomPom] run function skill:act/summoner/pompom/hit
+#白魔導士
+execute if entity @s[tag=ShiningBolt] run function makeup:skill/act/white_mage/shining_bolt/hit
+#黒魔導士
+execute if entity @s[tag=WindWallTornado] run function makeup:skill/act/black_mage/wind_wall/hit
+#共通
+execute if entity @s[tag=WeakPaint] at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:1000000f},distance=0] unless score @s Weakness matches 1.. run function skill:act/common/weakness_paint/hit

--- a/data/player/function/trigger/slept_in_bed/.mcfunction
+++ b/data/player/function/trigger/slept_in_bed/.mcfunction
@@ -1,0 +1,19 @@
+#> player:trigger/slept_in_bed/
+### ベッドイン時
+
+# 全員ベッドの上なら朝にする
+scoreboard players set _ _ 1
+execute as @a at @s unless block ~ ~ ~ #beds run scoreboard players set _ _ 0
+execute if score _ _ matches 1 run schedule function player:trigger/slept_in_bed/change_time 5s replace
+
+# Tips表示
+function player:tips/show
+
+# 黒魔導士 ルーラ ホームポイント
+function skill:act/black_mage/return/home_point/show
+
+# 難易度別処理 体力回復
+function main:difficulty/slept_in_bed
+
+tellraw @s {"translate":"ｽﾔｧ...( ˘ω˘ )","color":"aqua"}
+advancement revoke @s only player:trigger/slept_in_bed

--- a/data/player/function/trigger/slept_in_bed/change_time.mcfunction
+++ b/data/player/function/trigger/slept_in_bed/change_time.mcfunction
@@ -1,0 +1,7 @@
+#> player:trigger/slept_in_bed/change_time
+#夜を司る島攻略済みチェック
+execute unless data storage area: capture.skylands{011:1} run return fail
+#時間を朝にする
+scoreboard players set _ _ 1
+execute as @a at @s unless block ~ ~ ~ #beds run scoreboard players set _ _ 0
+execute if score _ _ matches 1 run time set 0

--- a/data/player/function/trigger/sneak.mcfunction
+++ b/data/player/function/trigger/sneak.mcfunction
@@ -1,0 +1,24 @@
+#> player:trigger/sneak
+###スニーク時処理
+
+#スニーク中   スニークしているときに実行したい処理はこの下に追加
+execute if score @s SneakTime matches 3 run scoreboard players add @s SneakTrigger 1
+#スニーク頻度
+execute if score @s SneakTime matches 1 run scoreboard players add @s SneakFrequency 10
+# スニークスキル
+execute if score @s[gamemode=!spectator] SneakTime matches 3 run function skill:trigger/sneak
+
+#スニーク解除   スニークし終わったときに実行したい処理はこの下に追加
+execute if score @s SneakTime matches ..2 run scoreboard players reset @s SneakTrigger
+
+# スニーク解除時スキル
+execute if score @s[gamemode=!spectator] SneakTime matches 2 if data entity @s[predicate=skill:trigger/weapon/] Inventory[{tag:{Skill:{Trigger:"剣を持った状態でスニーク解除"}}}] run function skill:trigger/after_sneak_skill
+
+# 近くに墓がある場合、墓からものを取り出す
+    execute if entity @s[scores={Age=1..},predicate=entity:player] if score @s SneakTime matches 3 as @e[type=item_display,tag=Tomb,distance=..1] at @s run function player:death_item_drop/tomb_drop
+
+##スニーク状態取得
+scoreboard players set _ _ 2
+scoreboard players operation @s SneakTime *= _ _
+scoreboard players set _ _ 4
+scoreboard players operation @s SneakTime %= _ _

--- a/data/player/function/trigger/sneak_frequency.mcfunction
+++ b/data/player/function/trigger/sneak_frequency.mcfunction
@@ -1,0 +1,15 @@
+#> player:trigger/sneak_frequency
+#スニーク頻度
+#スニークすると+10 毎Tick-1
+
+# バースト
+execute if score @s SneakFrequency matches 15 store result score _ _ run bossbar get skill:burst max
+execute if score @s SneakFrequency matches 15 run scoreboard players set _ Calc 3
+execute if score @s SneakFrequency matches 15 run scoreboard players operation _ _ /= _ Calc
+execute if entity @s[scores={Age=1..},predicate=entity:player] if score @s SneakFrequency matches 15 if score $World Burst > _ _ anchored eyes positioned ^ ^-0.85 ^5 run function skill:burst/command/show
+
+#設定表示
+execute if score @s SneakFrequency matches 20.. run function player:game_settings/show
+execute if score @s SneakFrequency matches 20.. run scoreboard players set @s SneakFrequency 1
+
+scoreboard players remove @s SneakFrequency 1

--- a/data/player/function/trigger/talk/.mcfunction
+++ b/data/player/function/trigger/talk/.mcfunction
@@ -1,0 +1,9 @@
+#> player:trigger/talk/
+### 村人会話時処理
+
+### 取引更新
+execute positioned ^ ^ ^2 as @e[tag=UpdateOffers,distance=..5] run function player:trigger/talk/update_offers
+### フレンドリー化
+execute positioned ^ ^ ^2 run team join Friendly @e[tag=WanderingVillager,distance=..5]
+### トリガーリセット
+scoreboard players reset @s Talk

--- a/data/player/function/trigger/talk/update_offers.mcfunction
+++ b/data/player/function/trigger/talk/update_offers.mcfunction
@@ -1,0 +1,9 @@
+#> player:trigger/talk/update_offers
+### 取引更新
+
+data remove storage tusb_mob: "即時ステータス"
+data modify entity 0-0-0-0-0 Tags set value []
+data modify entity 0-0-0-0-0 Tags set from entity @s ArmorItems[0].components."minecraft:custom_data".SpawnTags
+execute as 0-0-0-0-0 run function settings:enemy/
+data modify entity @s Offers set from storage tusb_mob: "即時ステータス"."ベース".Offers
+execute at @s facing entity @a[limit=1,sort=nearest] eyes rotated ~ 0 run tp @s ~ ~ ~ ~ ~

--- a/data/player/function/trigger/trade/.mcfunction
+++ b/data/player/function/trigger/trade/.mcfunction
@@ -1,0 +1,8 @@
+#> player:trigger/trade/
+### 取引時処理
+
+### LimitedTrades
+execute as @e[tag=LimitedTrades,distance=..8] at @s positioned ~ ~0.5 ~ if entity @e[type=experience_orb,distance=0] run function player:trigger/trade/limited_trades
+
+### トリガーリセット
+scoreboard players reset @s Trade

--- a/data/player/function/trigger/trade/limited_trades.mcfunction
+++ b/data/player/function/trigger/trade/limited_trades.mcfunction
@@ -1,0 +1,6 @@
+#> player:trigger/trade/limited_trades
+### LimitedTrades
+
+execute store result entity @s DeathLootTableSeed long 0.99999 run data get entity @s DeathLootTableSeed
+execute unless data entity @s DeathLootTableSeed run data modify entity @s {} merge value {DeathTime:19s,Silent:1b,Tags:[Garbage]}
+execute unless data entity @s DeathLootTableSeed run tellraw @a[distance=..16] [{"translate":"%1$s は去っていった。","with":[{"selector":"@s"}]}]

--- a/data/player/function/trigger/use/bow.mcfunction
+++ b/data/player/function/trigger/use/bow.mcfunction
@@ -1,0 +1,20 @@
+#> player:trigger/use/bow
+#装備を取得
+function player:load_equipments
+#メインハンドがトリガーのアイテムでなければ交換
+execute unless data storage item: SelectedItem{id:"minecraft:bow"} run function player:trigger/use/if_not_mainhand
+#物理ダメージ取得
+function skill:damage/add/physical/projectile
+#属性ダメージ取得
+function skill:damage/add/elemental
+#ピアッシングエイム適用
+execute if score @s PiercingAim matches 1.. run function skill:act/hunter/piercing_aim/apply0
+#スキル
+function skill:equipments_to_items
+data remove storage item: Item
+data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"弓を構えて矢を撃つ"}}}]
+execute if data storage item: Item.tag.Skill{Trigger:"弓を構えて矢を撃つ"} run function skill:practice/
+#ダメージと装備を保存
+execute as @e[type=#minecraft:impact_projectiles,tag=!Initialized,distance=..2] run function player:trigger/projectile/save
+#トリガーリセット
+scoreboard players reset @s UseBow

--- a/data/player/function/trigger/use/carrot_on_a_stick.mcfunction
+++ b/data/player/function/trigger/use/carrot_on_a_stick.mcfunction
@@ -1,3 +1,4 @@
+#> player:trigger/use/carrot_on_a_stick
 #装備を取得
 function player:load_equipments
 #スキル

--- a/data/player/function/trigger/use/carrot_on_a_stick.mcfunction
+++ b/data/player/function/trigger/use/carrot_on_a_stick.mcfunction
@@ -1,0 +1,9 @@
+#装備を取得
+function player:load_equipments
+#スキル
+function skill:equipments_to_items
+data remove storage item: Item
+data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"手に持って右クリック"}}}]
+execute if data storage item: Item.tag.Skill{Trigger:"手に持って右クリック"} run function skill:practice/
+#トリガーリセット
+scoreboard players reset @s UseCarrotStick

--- a/data/player/function/trigger/use/crossbow.mcfunction
+++ b/data/player/function/trigger/use/crossbow.mcfunction
@@ -1,0 +1,20 @@
+#> player:trigger/use/crossbow
+#装備を取得
+function player:load_equipments
+#メインハンドがトリガーのアイテムでなければ交換
+execute unless data storage item: SelectedItem{id:"minecraft:crossbow"} run function player:trigger/use/if_not_mainhand
+#物理ダメージ取得
+function skill:damage/add/physical/projectile
+#属性ダメージ取得
+function skill:damage/add/elemental
+#ピアッシングエイム適用
+execute if score @s PiercingAim matches 1.. run function skill:act/hunter/piercing_aim/apply0
+#スキル
+function skill:equipments_to_items
+data remove storage item: Item
+data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"クロスボウを構えて矢を撃つ"}}}]
+execute if data storage item: Item.tag.Skill{Trigger:"クロスボウを構えて矢を撃つ"} run function skill:practice/
+#ダメージと装備を保存
+execute as @e[type=#minecraft:impact_projectiles,tag=!Initialized,distance=..2] run function player:trigger/projectile/save
+#トリガーリセット
+scoreboard players reset @s UseCrossbow

--- a/data/player/function/trigger/use/ender_pearl.mcfunction
+++ b/data/player/function/trigger/use/ender_pearl.mcfunction
@@ -1,0 +1,12 @@
+#> player:trigger/use/ender_pearl
+### エンダーパール すり抜け抑制
+scoreboard players set _ _ 0
+execute store success score _ _ as @e[type=ender_pearl,distance=..1] on origin if entity @s[advancements={player:trigger/use/ender_pearl=true}] align xyz positioned ~0.5 ~ ~0.5 run tp @s ~ ~ ~
+execute if score _ _ matches 1 run scoreboard players remove @s UseEnderPearl 1
+
+# エンダーパールが無くなればreset
+scoreboard players set _ _ 0
+execute store success score _ _ as @e[type=ender_pearl,distance=1..128] on origin if entity @s[advancements={player:trigger/use/ender_pearl=true}]
+execute if score _ _ matches 0 run scoreboard players reset @s UseEnderPearl
+
+advancement revoke @s only player:trigger/use/ender_pearl

--- a/data/player/function/trigger/use/if_not_mainhand.mcfunction
+++ b/data/player/function/trigger/use/if_not_mainhand.mcfunction
@@ -1,0 +1,7 @@
+#> player:trigger/use/if_not_mainhand
+# メインハンドのアイテムでトリガーが実行されていないとき
+# オフハンドとメインハンドを好感して処理する
+
+data modify storage item: SelectedItem set from storage item: Equipments[{Slot:-106b}]
+data remove storage item: Equipments[{Slot:-106b}]
+data modify storage item: Equipments prepend from storage item: SelectedItem

--- a/data/player/function/trigger/use/magma_cube_spawn_egg.mcfunction
+++ b/data/player/function/trigger/use/magma_cube_spawn_egg.mcfunction
@@ -1,0 +1,5 @@
+###印版設置
+execute as @e[tag=Sign,type=magma_cube,distance=..7] positioned as @s run function item:sign/set/
+
+### トリガーリセット
+scoreboard players reset @s UseMagmaCubeEgg

--- a/data/player/function/trigger/use/magma_cube_spawn_egg.mcfunction
+++ b/data/player/function/trigger/use/magma_cube_spawn_egg.mcfunction
@@ -1,3 +1,4 @@
+#> player:trigger/use/magma_cube_spawn_egg
 ###印版設置
 execute as @e[tag=Sign,type=magma_cube,distance=..7] positioned as @s run function item:sign/set/
 

--- a/data/player/function/trigger/use/shield.mcfunction
+++ b/data/player/function/trigger/use/shield.mcfunction
@@ -1,0 +1,13 @@
+#> player:trigger/use/shield
+### 盾で防御
+
+#装備を取得
+function player:load_equipments
+
+### スキル
+function skill:equipments_to_items
+data remove storage item: Item
+data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"盾で攻撃を防ぐ"}}}]
+execute if data storage item: Item.tag.Skill{Trigger:"盾で攻撃を防ぐ"} run function skill:practice/
+#トリガーリセット
+advancement revoke @s only player:trigger/use/shield

--- a/data/player/function/trigger/use/trident.mcfunction
+++ b/data/player/function/trigger/use/trident.mcfunction
@@ -1,0 +1,13 @@
+#> player:trigger/use/trident
+#装備を取得
+function player:load_equipments
+#メインハンドがトリガーのアイテムでなければ交換
+execute unless data storage item: SelectedItem{id:"minecraft:trident"} run function player:trigger/use/if_not_mainhand
+#物理ダメージ取得
+function skill:damage/add/physical/projectile
+#属性ダメージ取得
+function skill:damage/add/elemental
+##ダメージと装備を保存
+execute as @e[type=#minecraft:impact_projectiles,tag=!Initialized,distance=..2] run function player:trigger/projectile/save
+#トリガーリセット
+scoreboard players reset @s UseTrident

--- a/data/player/function/trigger/use/warped_fungus_on_a_stick.mcfunction
+++ b/data/player/function/trigger/use/warped_fungus_on_a_stick.mcfunction
@@ -1,0 +1,2 @@
+#トリガーリセット
+scoreboard players reset @s UseFungusStick

--- a/data/player/function/trigger/use/warped_fungus_on_a_stick.mcfunction
+++ b/data/player/function/trigger/use/warped_fungus_on_a_stick.mcfunction
@@ -1,2 +1,3 @@
+#> player:trigger/use/warped_fungus_on_a_stick
 #トリガーリセット
 scoreboard players reset @s UseFungusStick

--- a/data/player/function/trigger/using/shield/.mcfunction
+++ b/data/player/function/trigger/using/shield/.mcfunction
@@ -1,0 +1,5 @@
+#> player:trigger/using/shield/
+#前方のEnemyProjectileをブロック
+execute anchored eyes positioned ^ ^ ^0.5 positioned ~-0.75 ~-2 ~-0.75 as @e[tag=EnemyProjectile,dx=0.5,dy=1.8,dz=0.5] at @s run function player:trigger/using/shield/block
+execute store result score @s ShieldUsingTick run time query gametime
+advancement revoke @s only player:trigger/using/shield

--- a/data/player/function/trigger/using/shield/block.mcfunction
+++ b/data/player/function/trigger/using/shield/block.mcfunction
@@ -1,0 +1,8 @@
+#> player:trigger/using/shield/block
+#前方のEnemyProjectileをブロック
+function makeup:player/trigger/using/shield
+kill @s[tag=!Enemy]
+#敵の場合1ダメージ与えて反射
+execute if entity @s[tag=Enemy,tag=SmartMotion] facing ^ ^ ^-1 run function smart_motion:core/tp
+execute if entity @s[tag=Enemy,tag=!SmartMotion] facing ^ ^ ^-1 run tp @s ~ ~ ~ ~ ~
+execute store result entity @s[tag=Enemy] AbsorptionAmount float 0.999999 run data get entity @s AbsorptionAmount

--- a/data/player/function/trigger/void_death/.mcfunction
+++ b/data/player/function/trigger/void_death/.mcfunction
@@ -1,0 +1,9 @@
+#> player:trigger/void_death/
+### 奈落死：Y-64以下、voidディメンション、呪詛
+# 難易度分岐
+
+# カジュアル処理(呪詛)
+    execute if data storage main: difficult{world:"casual"} run function player:death_item_drop/casual_curse
+
+# エキスパート(呪詛)
+    execute if data storage main: difficult{world:"expert"} run function player:death_item_drop/expert_curse

--- a/data/player/function/trigger/void_death/delete_loop.mcfunction
+++ b/data/player/function/trigger/void_death/delete_loop.mcfunction
@@ -1,0 +1,4 @@
+#> player:trigger/void_death/delete_loop
+#3000個になるまで削除
+data remove storage item: Items[0]
+execute if data storage item: Items[3000] run function player:trigger/void_death/delete_loop


### PR DESCRIPTION
Close #378 

プレイヤーの各主動作でトリガーします。

`player:tick`を`as @a at @s`で実行してください。
どのトリガーも、トリガーされてそのトリガーが解除・リセットされるまでのみしか動作確認していません。
内部のコードは移したままですが、その動作は保証しません。

アイテムのコンポーネント化に伴い、NBTパスもそれに対応させました。
しかしそれで動作するとは限りません(´・ω・｀)

トリガーの中で`hurt_entity`トリガーのみ実装していません。これはダメージに関する仕様の大幅変更とAbsorptionAmountの仕様変更のせいで大きく修正する必要があるためです。
このコードは別でdraftとして出すかもしれません。なので今回のPRにはありません。