### PR TITLE
#384 mincraft空間のアップデート対応

### DIFF
--- a/data/minecraft/advancement/adventure/adventuring_time.json
+++ b/data/minecraft/advancement/adventure/adventuring_time.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/arbalistic.json
+++ b/data/minecraft/advancement/adventure/arbalistic.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/avoid_vibration.json
+++ b/data/minecraft/advancement/adventure/avoid_vibration.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/blowback.json
+++ b/data/minecraft/advancement/adventure/blowback.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/brush_armadillo.json
+++ b/data/minecraft/advancement/adventure/brush_armadillo.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/bullseye.json
+++ b/data/minecraft/advancement/adventure/bullseye.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/craft_decorated_pot_using_only_sherds.json
+++ b/data/minecraft/advancement/adventure/craft_decorated_pot_using_only_sherds.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/crafters_crafting_crafters.json
+++ b/data/minecraft/advancement/adventure/crafters_crafting_crafters.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/fall_from_world_height.json
+++ b/data/minecraft/advancement/adventure/fall_from_world_height.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/hero_of_the_village.json
+++ b/data/minecraft/advancement/adventure/hero_of_the_village.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/honey_block_slide.json
+++ b/data/minecraft/advancement/adventure/honey_block_slide.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/kill_a_mob.json
+++ b/data/minecraft/advancement/adventure/kill_a_mob.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/kill_all_mobs.json
+++ b/data/minecraft/advancement/adventure/kill_all_mobs.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/kill_mob_near_sculk_catalyst.json
+++ b/data/minecraft/advancement/adventure/kill_mob_near_sculk_catalyst.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/lighten_up.json
+++ b/data/minecraft/advancement/adventure/lighten_up.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/lightning_rod_with_villager_no_fire.json
+++ b/data/minecraft/advancement/adventure/lightning_rod_with_villager_no_fire.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/minecraft_trials_edition.json
+++ b/data/minecraft/advancement/adventure/minecraft_trials_edition.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/ol_betsy.json
+++ b/data/minecraft/advancement/adventure/ol_betsy.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/overoverkill.json
+++ b/data/minecraft/advancement/adventure/overoverkill.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/play_jukebox_in_meadows.json
+++ b/data/minecraft/advancement/adventure/play_jukebox_in_meadows.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/read_power_of_chiseled_bookshelf.json
+++ b/data/minecraft/advancement/adventure/read_power_of_chiseled_bookshelf.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/revaulting.json
+++ b/data/minecraft/advancement/adventure/revaulting.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/root.json
+++ b/data/minecraft/advancement/adventure/root.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/salvage_sherd.json
+++ b/data/minecraft/advancement/adventure/salvage_sherd.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/shoot_arrow.json
+++ b/data/minecraft/advancement/adventure/shoot_arrow.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/sleep_in_bed.json
+++ b/data/minecraft/advancement/adventure/sleep_in_bed.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/sniper_duel.json
+++ b/data/minecraft/advancement/adventure/sniper_duel.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/spyglass_at_dragon.json
+++ b/data/minecraft/advancement/adventure/spyglass_at_dragon.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/spyglass_at_ghast.json
+++ b/data/minecraft/advancement/adventure/spyglass_at_ghast.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/spyglass_at_parrot.json
+++ b/data/minecraft/advancement/adventure/spyglass_at_parrot.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/summon_iron_golem.json
+++ b/data/minecraft/advancement/adventure/summon_iron_golem.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/throw_trident.json
+++ b/data/minecraft/advancement/adventure/throw_trident.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/totem_of_undying.json
+++ b/data/minecraft/advancement/adventure/totem_of_undying.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/trade.json
+++ b/data/minecraft/advancement/adventure/trade.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/trade_at_world_height.json
+++ b/data/minecraft/advancement/adventure/trade_at_world_height.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/trim_with_all_exclusive_armor_patterns.json
+++ b/data/minecraft/advancement/adventure/trim_with_all_exclusive_armor_patterns.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/trim_with_any_armor_pattern.json
+++ b/data/minecraft/advancement/adventure/trim_with_any_armor_pattern.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/two_birds_one_arrow.json
+++ b/data/minecraft/advancement/adventure/two_birds_one_arrow.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/under_lock_and_key.json
+++ b/data/minecraft/advancement/adventure/under_lock_and_key.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/very_very_frightening.json
+++ b/data/minecraft/advancement/adventure/very_very_frightening.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/voluntary_exile.json
+++ b/data/minecraft/advancement/adventure/voluntary_exile.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/walk_on_powder_snow_with_leather_boots.json
+++ b/data/minecraft/advancement/adventure/walk_on_powder_snow_with_leather_boots.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/who_needs_rockets.json
+++ b/data/minecraft/advancement/adventure/who_needs_rockets.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/adventure/whos_the_pillager_now.json
+++ b/data/minecraft/advancement/adventure/whos_the_pillager_now.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/dragon_breath.json
+++ b/data/minecraft/advancement/end/dragon_breath.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/dragon_egg.json
+++ b/data/minecraft/advancement/end/dragon_egg.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/elytra.json
+++ b/data/minecraft/advancement/end/elytra.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/enter_end_gateway.json
+++ b/data/minecraft/advancement/end/enter_end_gateway.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/find_end_city.json
+++ b/data/minecraft/advancement/end/find_end_city.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/kill_dragon.json
+++ b/data/minecraft/advancement/end/kill_dragon.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/levitate.json
+++ b/data/minecraft/advancement/end/levitate.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/respawn_dragon.json
+++ b/data/minecraft/advancement/end/respawn_dragon.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/end/root.json
+++ b/data/minecraft/advancement/end/root.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/allay_deliver_cake_to_note_block.json
+++ b/data/minecraft/advancement/husbandry/allay_deliver_cake_to_note_block.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/allay_deliver_item_to_player.json
+++ b/data/minecraft/advancement/husbandry/allay_deliver_item_to_player.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/axolotl_in_a_bucket.json
+++ b/data/minecraft/advancement/husbandry/axolotl_in_a_bucket.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/balanced_diet.json
+++ b/data/minecraft/advancement/husbandry/balanced_diet.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/bred_all_animals.json
+++ b/data/minecraft/advancement/husbandry/bred_all_animals.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/breed_an_animal.json
+++ b/data/minecraft/advancement/husbandry/breed_an_animal.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/complete_catalogue.json
+++ b/data/minecraft/advancement/husbandry/complete_catalogue.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/feed_snifflet.json
+++ b/data/minecraft/advancement/husbandry/feed_snifflet.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/fishy_business.json
+++ b/data/minecraft/advancement/husbandry/fishy_business.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/froglights.json
+++ b/data/minecraft/advancement/husbandry/froglights.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/kill_axolotl_target.json
+++ b/data/minecraft/advancement/husbandry/kill_axolotl_target.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/leash_all_frog_variants.json
+++ b/data/minecraft/advancement/husbandry/leash_all_frog_variants.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/make_a_sign_glow.json
+++ b/data/minecraft/advancement/husbandry/make_a_sign_glow.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/obtain_netherite_hoe.json
+++ b/data/minecraft/advancement/husbandry/obtain_netherite_hoe.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/obtain_sniffer_egg.json
+++ b/data/minecraft/advancement/husbandry/obtain_sniffer_egg.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/plant_any_sniffer_seed.json
+++ b/data/minecraft/advancement/husbandry/plant_any_sniffer_seed.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/plant_seed.json
+++ b/data/minecraft/advancement/husbandry/plant_seed.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/remove_wolf_armor.json
+++ b/data/minecraft/advancement/husbandry/remove_wolf_armor.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/repair_wolf_armor.json
+++ b/data/minecraft/advancement/husbandry/repair_wolf_armor.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/ride_a_boat_with_a_goat.json
+++ b/data/minecraft/advancement/husbandry/ride_a_boat_with_a_goat.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/root.json
+++ b/data/minecraft/advancement/husbandry/root.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/safely_harvest_honey.json
+++ b/data/minecraft/advancement/husbandry/safely_harvest_honey.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/silk_touch_nest.json
+++ b/data/minecraft/advancement/husbandry/silk_touch_nest.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/tactical_fishing.json
+++ b/data/minecraft/advancement/husbandry/tactical_fishing.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/tadpole_in_a_bucket.json
+++ b/data/minecraft/advancement/husbandry/tadpole_in_a_bucket.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/tame_an_animal.json
+++ b/data/minecraft/advancement/husbandry/tame_an_animal.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/wax_off.json
+++ b/data/minecraft/advancement/husbandry/wax_off.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/wax_on.json
+++ b/data/minecraft/advancement/husbandry/wax_on.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/husbandry/whole_pack.json
+++ b/data/minecraft/advancement/husbandry/whole_pack.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/all_effects.json
+++ b/data/minecraft/advancement/nether/all_effects.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/all_potions.json
+++ b/data/minecraft/advancement/nether/all_potions.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/brew_potion.json
+++ b/data/minecraft/advancement/nether/brew_potion.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/charge_respawn_anchor.json
+++ b/data/minecraft/advancement/nether/charge_respawn_anchor.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/create_beacon.json
+++ b/data/minecraft/advancement/nether/create_beacon.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/create_full_beacon.json
+++ b/data/minecraft/advancement/nether/create_full_beacon.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/distract_piglin.json
+++ b/data/minecraft/advancement/nether/distract_piglin.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/explore_nether.json
+++ b/data/minecraft/advancement/nether/explore_nether.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/fast_travel.json
+++ b/data/minecraft/advancement/nether/fast_travel.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/find_bastion.json
+++ b/data/minecraft/advancement/nether/find_bastion.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/find_fortress.json
+++ b/data/minecraft/advancement/nether/find_fortress.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/get_wither_skull.json
+++ b/data/minecraft/advancement/nether/get_wither_skull.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/loot_bastion.json
+++ b/data/minecraft/advancement/nether/loot_bastion.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/netherite_armor.json
+++ b/data/minecraft/advancement/nether/netherite_armor.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/obtain_ancient_debris.json
+++ b/data/minecraft/advancement/nether/obtain_ancient_debris.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/obtain_blaze_rod.json
+++ b/data/minecraft/advancement/nether/obtain_blaze_rod.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/obtain_crying_obsidian.json
+++ b/data/minecraft/advancement/nether/obtain_crying_obsidian.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/return_to_sender.json
+++ b/data/minecraft/advancement/nether/return_to_sender.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/ride_strider.json
+++ b/data/minecraft/advancement/nether/ride_strider.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/ride_strider_in_overworld_lava.json
+++ b/data/minecraft/advancement/nether/ride_strider_in_overworld_lava.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/root.json
+++ b/data/minecraft/advancement/nether/root.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/summon_wither.json
+++ b/data/minecraft/advancement/nether/summon_wither.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/uneasy_alliance.json
+++ b/data/minecraft/advancement/nether/uneasy_alliance.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/nether/use_lodestone.json
+++ b/data/minecraft/advancement/nether/use_lodestone.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/recipes/decorations/ender_chest.json
+++ b/data/minecraft/advancement/recipes/decorations/ender_chest.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/recipes/misc/beacon.json
+++ b/data/minecraft/advancement/recipes/misc/beacon.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/recipes/misc/firework_rocket_simple.json
+++ b/data/minecraft/advancement/recipes/misc/firework_rocket_simple.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_axe.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_axe.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_axe"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_axe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_boots.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_boots.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_boots"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_boots"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_chestplate.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_chestplate.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_chestplate"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_chestplate"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_helmet.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_helmet.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_helmet"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_helmet"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_hoe.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_hoe.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_hoe"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_hoe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_leggings.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_leggings.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_leggings"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_leggings"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_pickaxe.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_pickaxe.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_pickaxe"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_pickaxe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_shovel.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_shovel.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_shovel"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_shovel"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/recipes/tools/netherite_sword.json
+++ b/data/minecraft/advancement/recipes/tools/netherite_sword.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:netherite_sword"
+    ]
+  },
+  "criteria": {
+    "has_netherite_ingot": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "minecraft:netherite_sword"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_ingot",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/data/minecraft/advancement/story/cure_zombie_villager.json
+++ b/data/minecraft/advancement/story/cure_zombie_villager.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/deflect_arrow.json
+++ b/data/minecraft/advancement/story/deflect_arrow.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/enchant_item.json
+++ b/data/minecraft/advancement/story/enchant_item.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/enter_the_end.json
+++ b/data/minecraft/advancement/story/enter_the_end.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/enter_the_nether.json
+++ b/data/minecraft/advancement/story/enter_the_nether.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/follow_ender_eye.json
+++ b/data/minecraft/advancement/story/follow_ender_eye.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/form_obsidian.json
+++ b/data/minecraft/advancement/story/form_obsidian.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/iron_tools.json
+++ b/data/minecraft/advancement/story/iron_tools.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/lava_bucket.json
+++ b/data/minecraft/advancement/story/lava_bucket.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/mine_diamond.json
+++ b/data/minecraft/advancement/story/mine_diamond.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/mine_stone.json
+++ b/data/minecraft/advancement/story/mine_stone.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/obtain_armor.json
+++ b/data/minecraft/advancement/story/obtain_armor.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/root.json
+++ b/data/minecraft/advancement/story/root.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/shiny_gear.json
+++ b/data/minecraft/advancement/story/shiny_gear.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/smelt_iron.json
+++ b/data/minecraft/advancement/story/smelt_iron.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/advancement/story/upgrade_tools.json
+++ b/data/minecraft/advancement/story/upgrade_tools.json
@@ -1,0 +1,7 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}

--- a/data/minecraft/loot_table/blocks/acacia_leaves.json
+++ b/data/minecraft/loot_table/blocks/acacia_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:acacia_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:acacia_sapling"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/azalea_leaves.json
+++ b/data/minecraft/loot_table/blocks/azalea_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:azalea_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:azalea"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/beetroots.json
+++ b/data/minecraft/loot_table/blocks/beetroots.json
@@ -1,0 +1,118 @@
+{
+  "type": "minecraft:block",
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
+    }
+  ],
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "block": "minecraft:beetroots",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "age": "3"
+                  }
+                }
+              ],
+              "name": "minecraft:beetroot"
+            },
+            {
+              "type": "minecraft:item",
+              "name": "minecraft:beetroot_seeds"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:beetroots",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "3"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 3,
+                "probability": 0.5714286
+              }
+            }
+          ],
+          "name": "minecraft:beetroot_seeds"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.7814286
+              }
+            }
+          ],
+          "name": "minecraft:beetroot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:beetroots",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "3"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.06
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier1_4/harvest"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/birch_leaves.json
+++ b/data/minecraft/loot_table/blocks/birch_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:birch_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:birch_sapling"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/carrots.json
+++ b/data/minecraft/loot_table/blocks/carrots.json
@@ -1,0 +1,120 @@
+{
+  "type": "minecraft:block",
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
+    }
+  ],
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:carrot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:carrots",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 3,
+                "probability": 0.7714286
+              }
+            }
+          ],
+          "name": "minecraft:carrot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:carrots",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.01
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier1_4/harvest"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:carrots",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.1
+              }
+            }
+          ],
+          "name": "minecraft:golden_carrot"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/cobweb.json
+++ b/data/minecraft/loot_table/blocks/cobweb.json
@@ -1,0 +1,59 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:loot_table",
+              "value": "item:item/cobweb/adv_cobweb",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "minecraft:string"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/dark_oak_leaves.json
+++ b/data/minecraft/loot_table/blocks/dark_oak_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:dark_oak_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:dark_oak_sapling"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/flowering_azalea_leaves.json
+++ b/data/minecraft/loot_table/blocks/flowering_azalea_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:flowering_azalea_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:flowering_azalea"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/gravel.json
+++ b/data/minecraft/loot_table/blocks/gravel.json
@@ -1,0 +1,45 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "name": "minecraft:gravel",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "predicates": {
+                      "enchantments": [
+                        {
+                          "enchantments": "silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type": "minecraft:loot_table",
+              "value": "item:group/block/gravel",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/jungle_leaves.json
+++ b/data/minecraft/loot_table/blocks/jungle_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:jungle_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:jungle_sapling"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/mangrove_leaves.json
+++ b/data/minecraft/loot_table/blocks/mangrove_leaves.json
@@ -1,0 +1,214 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:mangrove_leaves"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/nether_wart.json
+++ b/data/minecraft/loot_table/blocks/nether_wart.json
@@ -1,0 +1,92 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "add": false,
+              "conditions": [
+                {
+                  "block": "minecraft:nether_wart",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "age": "3"
+                  }
+                }
+              ],
+              "count": {
+                "type": "minecraft:uniform",
+                "max": 4.0,
+                "min": 2.0
+              },
+              "function": "minecraft:set_count"
+            },
+            {
+              "conditions": [
+                {
+                  "block": "minecraft:nether_wart",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "age": "3"
+                  }
+                }
+              ],
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:uniform_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "bonusMultiplier": 1.5
+              }
+            }
+          ],
+          "name": "minecraft:nether_wart"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:explosion_decay"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:nether_wart",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "3"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.045
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier1_4/harvest"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/oak_leaves.json
+++ b/data/minecraft/loot_table/blocks/oak_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:oak_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:oak_sapling"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/potatoes.json
+++ b/data/minecraft/loot_table/blocks/potatoes.json
@@ -1,0 +1,110 @@
+{
+  "type": "minecraft:block",
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
+    }
+  ],
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:potato"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:potatoes",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 3,
+                "probability": 0.7714286
+              }
+            }
+          ],
+          "name": "minecraft:potato"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:potatoes",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.04
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier1_4/harvest"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:potatoes",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "chance": 0.02,
+              "condition": "minecraft:random_chance"
+            }
+          ],
+          "name": "minecraft:poisonous_potato"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/shulker_box.json
+++ b/data/minecraft/loot_table/blocks/shulker_box.json
@@ -1,0 +1,45 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:dynamic",
+              "name": "minecraft:contents",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "items": [
+                      "minecraft:debug_stick"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "function": "minecraft:copy_components",
+                  "include": [
+                    "minecraft:custom_name",
+                    "minecraft:container",
+                    "minecraft:lock",
+                    "minecraft:container_loot"
+                  ],
+                  "source": "block_entity"
+                }
+              ],
+              "name": "minecraft:shulker_box"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/spawner.json
+++ b/data/minecraft/loot_table/blocks/spawner.json
@@ -1,0 +1,198 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lodestone",
+          "functions": [
+            {
+              "function": "minecraft:set_custom_data",
+              "tag": "{NoHold:1b,ExplodedLodestone:1b}"
+            }
+          ]
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "count": 1
+            }
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lodestone"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:set_custom_data",
+          "tag": "{NoHold:1b,DamageItem:1b,SpawnerDamage:5}"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:wooden_pickaxe",
+              "minecraft:wooden_axe",
+              "minecraft:wooden_shovel",
+              "minecraft:wooden_hoe"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lodestone"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:set_custom_data",
+          "tag": "{NoHold:1b,DamageItem:1b,SpawnerDamage:10}"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:stone_pickaxe",
+              "minecraft:stone_axe",
+              "minecraft:stone_shovel",
+              "minecraft:stone_hoe"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lodestone"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:set_custom_data",
+          "tag": "{NoHold:1b,DamageItem:1b,SpawnerDamage:20}"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:iron_pickaxe",
+              "minecraft:iron_axe",
+              "minecraft:iron_shovel",
+              "minecraft:iron_hoe"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lodestone"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:set_custom_data",
+          "tag": "{NoHold:1b,DamageItem:1b,SpawnerDamage:30}"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:golden_pickaxe",
+              "minecraft:golden_axe",
+              "minecraft:golden_shovel",
+              "minecraft:golden_hoe"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lodestone"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:set_custom_data",
+          "tag": "{NoHold:1b,DamageItem:1b,SpawnerDamage:40}"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:diamond_pickaxe",
+              "minecraft:diamond_axe",
+              "minecraft:diamond_shovel",
+              "minecraft:diamond_hoe"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:lodestone"
+        }
+      ],
+      "functions": [
+        {
+          "function": "minecraft:set_custom_data",
+          "tag": "{NoHold:1b,DamageItem:1b,SpawnerDamage:60}"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:netherite_pickaxe",
+              "minecraft:netherite_axe",
+              "minecraft:netherite_shovel",
+              "minecraft:netherite_hoe"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/spruce_leaves.json
+++ b/data/minecraft/loot_table/blocks/spruce_leaves.json
@@ -1,0 +1,227 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:any_of",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "predicates": {
+                          "enchantments": [
+                            {
+                              "enchantments": "silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:spruce_leaves"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                },
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.0375
+                }
+              ],
+              "name": "minecraft:spruce_sapling"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "enchantments": [
+                    {
+                      "enchantments": "fortune",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "name": "minecraft:stick"
+        }
+      ]
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "condition": "minecraft:survives_explosion"
+            },
+            {
+              "chances": [
+                0.00625,
+                0.006944444625,
+                0.0078125,
+                0.0104166675,
+                0.03125,
+                0.04375,
+                0.065625,
+                0.105,
+                0.2362499622000045
+              ],
+              "condition": "minecraft:table_bonus",
+              "enchantment": "minecraft:fortune"
+            }
+          ],
+          "name": "minecraft:apple"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:inverted",
+          "term": {
+            "condition": "minecraft:any_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": [
+                    "minecraft:shears"
+                  ]
+                }
+              },
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "predicates": {
+                    "enchantments": [
+                      {
+                        "enchantments": "silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "predicates": {
+              "enchantments": [
+                {
+                  "enchantments": "fortune",
+                  "levels": {
+                    "min": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.05
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier3/leaves"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/torch.json
+++ b/data/minecraft/loot_table/blocks/torch.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:item/torch/adv_torch"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/vine.json
+++ b/data/minecraft/loot_table/blocks/vine.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:shears"
+            ]
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:item/vine/adv_vine"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/blocks/wheat.json
+++ b/data/minecraft/loot_table/blocks/wheat.json
@@ -1,0 +1,118 @@
+{
+  "type": "minecraft:block",
+  "functions": [
+    {
+      "function": "minecraft:explosion_decay"
+    }
+  ],
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "block": "minecraft:wheat",
+                  "condition": "minecraft:block_state_property",
+                  "properties": {
+                    "age": "7"
+                  }
+                }
+              ],
+              "name": "minecraft:wheat"
+            },
+            {
+              "type": "minecraft:item",
+              "name": "minecraft:wheat_seeds"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:wheat",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 3,
+                "probability": 0.5714286
+              }
+            }
+          ],
+          "name": "minecraft:wheat_seeds"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "function": "minecraft:apply_bonus",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.7714286
+              }
+            }
+          ],
+          "name": "minecraft:wheat"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "block": "minecraft:wheat",
+          "condition": "minecraft:block_state_property",
+          "properties": {
+            "age": "7"
+          }
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 0,
+              "add": false
+            },
+            {
+              "function": "minecraft:apply_bonus",
+              "enchantment": "minecraft:fortune",
+              "formula": "minecraft:binomial_with_bonus_count",
+              "parameters": {
+                "extra": 0,
+                "probability": 0.0625
+              }
+            }
+          ],
+          "value": "item:group/magic_stone/tier1_4/harvest"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/data/minecraft/loot_table/gameplay/fishing.json
+++ b/data/minecraft/loot_table/gameplay/fishing.json
@@ -1,0 +1,465 @@
+{
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/plains/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:plains"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/meadow/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:meadow"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/mushroom_fields/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:mushroom_fields"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/swamp/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:swamp"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/dark_forest/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:dark_forest"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/windswept_gravelly_hills/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:windswept_gravelly_hills"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/windswept_forest/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:windswept_forest"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/eroded_badlands/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:eroded_badlands"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/nether_wastes/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:nether_wastes"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/crimson_forest/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:crimson_forest"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/soul_sand_valley/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:soul_sand_valley"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/warped_forest/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:warped_forest"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/birch_forest/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:birch_forest"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/snowy_taiga/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:snowy_taiga"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/taiga/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:taiga"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/snowy_beach/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:snowy_beach"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/snowy_plains/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:snowy_plains"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/ice_spikes/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:ice_spikes"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/snowy_slopes/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:snowy_slopes"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/jungle/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:jungle"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/small_end_islands/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:small_end_islands"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/forest/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:forest"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/flower_forest/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:flower_forest"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/sunflower_plains/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:sunflower_plains"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/badlands/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:badlands"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/bamboo_jungle/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:bamboo_jungle"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/end_barrens/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:end_barrens"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/desert/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:desert"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/warm_ocean/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:warm_ocean"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/deep_cold_ocean/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:deep_cold_ocean"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/end_highlands/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:end_highlands"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/end_midlands/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:end_midlands"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/the_end/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:the_end"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/plains/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:plains"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/basalt_deltas/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:basalt_deltas"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/deep_ocean/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:deep_ocean"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/sparse_jungle/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:sparse_jungle"
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:loot_table",
+          "value": "item:group/fishing/river/",
+          "conditions": [
+            {
+              "condition": "minecraft:location_check",
+              "predicate": {
+                "biomes": "minecraft:river"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/minecraft/recipe/beacon.json
+++ b/data/minecraft/recipe/beacon.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "GGG",
+    "GSG",
+    "OOO"
+  ],
+  "key": {
+    "S": {
+      "item": "minecraft:nether_star"
+    },
+    "G": {
+      "item": "minecraft:glass"
+    },
+    "O": {
+      "item": "minecraft:bedrock"
+    }
+  },
+  "result": {
+    "id": "minecraft:beacon"
+  }
+}

--- a/data/minecraft/recipe/ender_chest.json
+++ b/data/minecraft/recipe/ender_chest.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "#E#",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:bedrock"
+    },
+    "E": {
+      "item": "minecraft:ender_eye"
+    }
+  },
+  "result": {
+    "id": "minecraft:ender_chest"
+  }
+}

--- a/data/minecraft/recipe/firework_rocket.json
+++ b/data/minecraft/recipe/firework_rocket.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:bedrock"
+    }
+  ],
+  "result": {
+    "id": "minecraft:bedrock"
+  }
+}

--- a/data/minecraft/recipe/firework_rocket_simple.json
+++ b/data/minecraft/recipe/firework_rocket_simple.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:bedrock"
+    },
+    {
+      "item": "minecraft:paper"
+    }
+  ],
+  "result": {
+    "id": "minecraft:firework_rocket",
+    "count": 3
+  }
+}

--- a/data/minecraft/recipe/golden_carrot.json
+++ b/data/minecraft/recipe/golden_carrot.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "#": {
+      "item": "minecraft:gold_nugget"
+    },
+    "X": {
+      "item": "minecraft:bedrock"
+    }
+  },
+  "pattern": [
+    "###",
+    "#X#",
+    "###"
+  ],
+  "result": {
+    "id": "minecraft:golden_carrot"
+  },
+  "show_notification": true
+}

--- a/data/minecraft/recipe/netherite_axe.json
+++ b/data/minecraft/recipe/netherite_axe.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_axe"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_axe"
+  }
+}

--- a/data/minecraft/recipe/netherite_axe_smithing.json
+++ b/data/minecraft/recipe/netherite_axe_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_axe"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_axe"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_boots.json
+++ b/data/minecraft/recipe/netherite_boots.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_boots"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_boots"
+  }
+}

--- a/data/minecraft/recipe/netherite_boots_smithing.json
+++ b/data/minecraft/recipe/netherite_boots_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_boots"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_boots"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_chestplate.json
+++ b/data/minecraft/recipe/netherite_chestplate.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_chestplate"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_chestplate"
+  }
+}

--- a/data/minecraft/recipe/netherite_chestplate_smithing.json
+++ b/data/minecraft/recipe/netherite_chestplate_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_chestplate"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_chestplate"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_helmet.json
+++ b/data/minecraft/recipe/netherite_helmet.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_helmet"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_helmet"
+  }
+}

--- a/data/minecraft/recipe/netherite_helmet_smithing.json
+++ b/data/minecraft/recipe/netherite_helmet_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_helmet"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_helmet"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_hoe.json
+++ b/data/minecraft/recipe/netherite_hoe.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_hoe"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_hoe"
+  }
+}

--- a/data/minecraft/recipe/netherite_hoe_smithing.json
+++ b/data/minecraft/recipe/netherite_hoe_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_hoe"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_hoe"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_leggings.json
+++ b/data/minecraft/recipe/netherite_leggings.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_leggings"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_leggings"
+  }
+}

--- a/data/minecraft/recipe/netherite_leggings_smithing.json
+++ b/data/minecraft/recipe/netherite_leggings_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_leggings"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_leggings"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_pickaxe.json
+++ b/data/minecraft/recipe/netherite_pickaxe.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_pickaxe"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_pickaxe"
+  }
+}

--- a/data/minecraft/recipe/netherite_pickaxe_smithing.json
+++ b/data/minecraft/recipe/netherite_pickaxe_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_pickaxe"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_pickaxe"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_shovel.json
+++ b/data/minecraft/recipe/netherite_shovel.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_shovel"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_shovel"
+  }
+}

--- a/data/minecraft/recipe/netherite_shovel_smithing.json
+++ b/data/minecraft/recipe/netherite_shovel_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_shovel"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_shovel"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/recipe/netherite_sword.json
+++ b/data/minecraft/recipe/netherite_sword.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:diamond_sword"
+    },
+    {
+      "item": "minecraft:netherite_ingot"
+    }
+  ],
+  "result": {
+    "id": "minecraft:netherite_sword"
+  }
+}

--- a/data/minecraft/recipe/netherite_sword_smithing.json
+++ b/data/minecraft/recipe/netherite_sword_smithing.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smithing_transform",
+  "base": {
+    "item": "minecraft:diamond_sword"
+  },
+  "addition": {
+    "item": "minecraft:bedrock"
+  },
+  "result": {
+    "id": "minecraft:netherite_sword"
+  },
+  "template": {
+    "item": "minecraft:netherite_upgrade_smithing_template"
+  }
+}

--- a/data/minecraft/tags/block/anvil.json
+++ b/data/minecraft/tags/block/anvil.json
@@ -1,0 +1,4 @@
+{
+  "replace": true,
+  "values": []
+}

--- a/data/minecraft/tags/block/beacon_base_blocks.json
+++ b/data/minecraft/tags/block/beacon_base_blocks.json
@@ -1,0 +1,9 @@
+{
+  "replace": true,
+  "values": [
+    "minecraft:barrier",
+    "minecraft:tnt",
+    "minecraft:cave_air",
+    "minecraft:bedrock"
+  ]
+}

--- a/data/minecraft/tags/block/mineable/axe.json
+++ b/data/minecraft/tags/block/mineable/axe.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:lodestone",
+    "minecraft:spawner"
+  ]
+}

--- a/data/minecraft/tags/block/mineable/hoe.json
+++ b/data/minecraft/tags/block/mineable/hoe.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:lodestone",
+    "minecraft:spawner"
+  ]
+}

--- a/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/data/minecraft/tags/block/mineable/pickaxe.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:anvil",
+    "minecraft:chipped_anvil",
+    "minecraft:damaged_anvil"
+  ]
+}

--- a/data/minecraft/tags/block/mineable/shovel.json
+++ b/data/minecraft/tags/block/mineable/shovel.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:lodestone",
+    "minecraft:spawner"
+  ]
+}

--- a/data/minecraft/tags/block/soul_speed_blocks.json
+++ b/data/minecraft/tags/block/soul_speed_blocks.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:soul_sand",
+    "minecraft:soul_soil",
+    "#minecraft:sand",
+    "minecraft:red_concrete_powder",
+    "minecraft:orange_concrete_powder",
+    "minecraft:brown_concrete_powder",
+    "minecraft:yellow_concrete_powder",
+    "minecraft:lime_concrete_powder",
+    "minecraft:green_concrete_powder",
+    "minecraft:cyan_concrete_powder",
+    "minecraft:light_blue_concrete_powder",
+    "minecraft:blue_concrete_powder",
+    "minecraft:purple_concrete_powder",
+    "minecraft:magenta_concrete_powder",
+    "minecraft:pink_concrete_powder",
+    "minecraft:white_concrete_powder",
+    "minecraft:light_gray_concrete_powder",
+    "minecraft:gray_concrete_powder",
+    "minecraft:black_concrete_powder"
+  ]
+}

--- a/data/minecraft/tags/function/load.json
+++ b/data/minecraft/tags/function/load.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "main:load",
+        "settings:version_update/check/"
+    ]
+}

--- a/data/minecraft/tags/function/tick.json
+++ b/data/minecraft/tags/function/tick.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "main:tick"
+    ]
+}

--- a/data/minecraft/tags/item/wool.json
+++ b/data/minecraft/tags/item/wool.json
@@ -1,0 +1,4 @@
+{
+  "replace": true,
+  "values": []
+}

--- a/data/minecraft/worldgen/biome/badlands.json
+++ b/data/minecraft/worldgen/biome/badlands.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 4408131,
     "water_fog_color": 4408131
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/bamboo_jungle.json
+++ b/data/minecraft/worldgen/biome/bamboo_jungle.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 4159204,
     "water_fog_color": 329011
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -45,10 +42,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/basalt_deltas.json
+++ b/data/minecraft/worldgen/biome/basalt_deltas.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 10535104,
     "water_fog_color": 10526912
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/birch_forest.json
+++ b/data/minecraft/worldgen/biome/birch_forest.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 8047605,
     "water_fog_color": 3448043
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/crimson_forest.json
+++ b/data/minecraft/worldgen/biome/crimson_forest.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 16776960,
     "water_fog_color": 16776960
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/dark_forest.json
+++ b/data/minecraft/worldgen/biome/dark_forest.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 4159204,
     "water_fog_color": 329011
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/deep_cold_ocean.json
+++ b/data/minecraft/worldgen/biome/deep_cold_ocean.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 13823999,
     "water_fog_color": 15727103
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/deep_ocean.json
+++ b/data/minecraft/worldgen/biome/deep_ocean.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 0,
     "water_fog_color": 16776960
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -45,10 +42,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/desert.json
+++ b/data/minecraft/worldgen/biome/desert.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -26,7 +25,6 @@
     "water_color": 13823999,
     "water_fog_color": 15727103
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -40,7 +38,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -57,10 +54,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/end_barrens.json
+++ b/data/minecraft/worldgen/biome/end_barrens.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 7548256,
     "water_fog_color": 7548256
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/end_highlands.json
+++ b/data/minecraft/worldgen/biome/end_highlands.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 16777215,
     "water_fog_color": 16777215
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -45,10 +42,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/end_midlands.json
+++ b/data/minecraft/worldgen/biome/end_midlands.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 16777215,
     "water_fog_color": 16777215
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/eroded_badlands.json
+++ b/data/minecraft/worldgen/biome/eroded_badlands.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 11330039,
     "water_fog_color": 3343652
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -45,10 +42,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/flower_forest.json
+++ b/data/minecraft/worldgen/biome/flower_forest.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 16711765,
     "water_fog_color": 16760576
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -44,10 +41,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/forest.json
+++ b/data/minecraft/worldgen/biome/forest.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 5614322,
     "water_fog_color": 1729413
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/ice_spikes.json
+++ b/data/minecraft/worldgen/biome/ice_spikes.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 54015,
     "water_fog_color": 13169151
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/jungle.json
+++ b/data/minecraft/worldgen/biome/jungle.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 4159204,
     "water_fog_color": 329011
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/meadow.json
+++ b/data/minecraft/worldgen/biome/meadow.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 4159204,
     "water_fog_color": 329011
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/mushroom_fields.json
+++ b/data/minecraft/worldgen/biome/mushroom_fields.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 6989903,
     "water_fog_color": 6989903
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/nether_wastes.json
+++ b/data/minecraft/worldgen/biome/nether_wastes.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 16776960,
     "water_fog_color": 16776960
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/ocean.json
+++ b/data/minecraft/worldgen/biome/ocean.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 255,
     "water_fog_color": 255
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/plains.json
+++ b/data/minecraft/worldgen/biome/plains.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 4159204,
     "water_fog_color": 329011
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -45,10 +42,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/small_end_islands.json
+++ b/data/minecraft/worldgen/biome/small_end_islands.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 16711680,
     "water_fog_color": 180
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -44,10 +41,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/snowy_beach.json
+++ b/data/minecraft/worldgen/biome/snowy_beach.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 8047605,
     "water_fog_color": 3448043
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -44,10 +41,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/snowy_plains.json
+++ b/data/minecraft/worldgen/biome/snowy_plains.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 3056104,
     "water_fog_color": 10279423
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/snowy_slopes.json
+++ b/data/minecraft/worldgen/biome/snowy_slopes.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 3056104,
     "water_fog_color": 10279423
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/snowy_taiga.json
+++ b/data/minecraft/worldgen/biome/snowy_taiga.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 16115834,
     "water_fog_color": 15454260
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/soul_sand_valley.json
+++ b/data/minecraft/worldgen/biome/soul_sand_valley.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 16776960,
     "water_fog_color": 16776960
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/sunflower_plains.json
+++ b/data/minecraft/worldgen/biome/sunflower_plains.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 5614322,
     "water_fog_color": 1729413
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/swamp.json
+++ b/data/minecraft/worldgen/biome/swamp.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 5782043,
     "water_fog_color": 5843969
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/taiga.json
+++ b/data/minecraft/worldgen/biome/taiga.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 16087771,
     "water_fog_color": 15414455
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/the_end.json
+++ b/data/minecraft/worldgen/biome/the_end.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 4372152,
     "water_fog_color": 4372152
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/warm_ocean.json
+++ b/data/minecraft/worldgen/biome/warm_ocean.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -20,7 +19,6 @@
     "water_color": 16711680,
     "water_fog_color": 11796480
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -34,7 +32,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -51,10 +48,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/warped_forest.json
+++ b/data/minecraft/worldgen/biome/warped_forest.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 65535,
     "water_fog_color": 14744575
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [],
     "creature": [],
@@ -38,10 +35,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": false,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/windswept_forest.json
+++ b/data/minecraft/worldgen/biome/windswept_forest.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 13945336,
     "water_fog_color": 14252696
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -45,10 +42,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }

--- a/data/minecraft/worldgen/biome/windswept_gravelly_hills.json
+++ b/data/minecraft/worldgen/biome/windswept_gravelly_hills.json
@@ -1,5 +1,4 @@
 {
-  "scale": 0.025,
   "effects": {
     "mood_sound": {
       "sound": "minecraft:ambient.cave",
@@ -14,7 +13,6 @@
     "water_color": 8684269,
     "water_fog_color": 2624381
   },
-  "surface_builder": "minecraft:nope",
   "carvers": {},
   "features": [
     [],
@@ -28,7 +26,6 @@
     [],
     []
   ],
-  "starts": [],
   "spawners": {
     "monster": [
       {
@@ -45,10 +42,7 @@
     "misc": []
   },
   "spawn_costs": {},
-  "player_spawn_friendly": false,
   "has_precipitation": true,
   "temperature": 0.5,
-  "downfall": 0.5,
-  "category": "none",
-  "depth": 0.0
+  "downfall": 0.5
 }


### PR DESCRIPTION
1.19.4の情報から1.21.1の情報へアップデートしました。
コンポーネント化への対応や、json内の変更や削除を行いました。

ルートテーブルにて、スポナーを破壊したときに双壊の情報を記録する仕組みがありましたが、現状ではできなさそうなので削除中です。
詳細は元issueを見てください。