### PR TITLE
add プレイヤー生き返り後処理

### DIFF
--- a/data/player/function/initialize.mcfunction
+++ b/data/player/function/initialize.mcfunction
@@ -2,7 +2,7 @@
 #OhMyDat登録
 function #oh_my_dat:please
 
-function player:rise/none_spawn_point
+execute unless data storage main: difficult{world:"debug"} run function player:rise/none_spawn_point
 
 #各種初期化
 data modify storage job: JobStatus set value [{},{},{},{},{},{},{},{},{}]

--- a/data/player/function/initialize.mcfunction
+++ b/data/player/function/initialize.mcfunction
@@ -2,7 +2,7 @@
 #OhMyDat登録
 function #oh_my_dat:please
 
-execute unless data storage main: difficult{world:"debug"} run function player:rise/none_spawn_point
+function player:rise/none_spawn_point
 
 #各種初期化
 data modify storage job: JobStatus set value [{},{},{},{},{},{},{},{},{}]

--- a/data/player/function/rise/.mcfunction
+++ b/data/player/function/rise/.mcfunction
@@ -26,7 +26,7 @@ execute if score _ _ matches 1 run function player:rise/enter_dimension
 
 ##### この先座標が変更される可能性があるため、at @s で位置を修正すること。
 ## プレイヤー初期リスポーン修正
-execute unless data entity @s SpawnForced run function player:rise/none_spawn_point
+execute unless data entity @s[tag=!HasRestoreItems,tag=!Raise] SpawnForced run function player:rise/none_spawn_point
 
 ### レスト・アイテム処理
 execute if entity @s[tag=HasRestoreItems,tag=!Raise] in area:control_area run function skill:act/common/restore_item/restore/

--- a/data/player/function/rise/.mcfunction
+++ b/data/player/function/rise/.mcfunction
@@ -1,0 +1,39 @@
+#> player:rise/
+###生き返り後処理
+
+##体力再設定
+#最大体力
+function effects:status/modify_max
+#MP超過修正
+scoreboard players operation @s MP < @s MPMax
+#ペイル再付与 ロック解除
+scoreboard players set _ _ -1
+execute if score @s PaleLevel matches ..-1 run scoreboard players operation @s PaleLevel *= _ _
+execute if score @s PaleLevel matches 0.. run function effects:pale/health_down
+execute if score @s PaleLevel matches 0.. run function makeup:effects/pale/apply
+#全回復
+effect give @s instant_health 1 10 true
+#MP表示修正
+function player:mp_bar/set
+
+##満腹度調整
+function effects:status/hunger
+
+## ディメンション移動処理
+function #oh_my_dat:please
+execute store success score _ _ run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathDimension set from entity @s Dimension
+execute if score _ _ matches 1 run function player:rise/enter_dimension
+
+##### この先座標が変更される可能性があるため、at @s で位置を修正すること。
+## プレイヤー初期リスポーン修正
+execute unless data entity @s SpawnForced run function player:rise/none_spawn_point
+
+### レスト・アイテム処理
+execute if entity @s[tag=HasRestoreItems,tag=!Raise] in area:control_area run function skill:act/common/restore_item/restore/
+execute if entity @s[tag=HasRestoreItems,tag=Raise] run function skill:act/common/restore_item/restore/cancel
+### レイズ処理
+execute if entity @s[tag=Raise] at @s run function skill:act/white_mage/araise/raise_check
+
+
+## フラグリセット
+scoreboard players reset @s Hunger

--- a/data/player/function/rise/enter_dimension.mcfunction
+++ b/data/player/function/rise/enter_dimension.mcfunction
@@ -1,0 +1,24 @@
+#> player:rise/enter_dimension
+execute if data entity @s {Dimension:"area:babel"} run function area:entered/babel
+execute if data entity @s {Dimension:"area:battle_area"} run function area:entered/battle_area
+execute if data entity @s {Dimension:"area:casino"} run function area:entered/casino
+execute if data entity @s {Dimension:"area:cloudia"} run function area:entered/cloudia
+execute if data entity @s {Dimension:"area:control_area"} run function area:entered/control_area
+execute if data entity @s {Dimension:"area:debug_room"} run function area:entered/debug_room
+execute if data entity @s {Dimension:"area:desert"} run function area:entered/desert
+execute if data entity @s {Dimension:"area:end"} run function area:entered/end
+execute if data entity @s {Dimension:"area:extra_domain"} run function area:entered/extra_domain
+execute if data entity @s {Dimension:"area:flying_island"} run function area:entered/flying_island
+execute if data entity @s {Dimension:"area:gullivers_land"} run function area:entered/gullivers_land
+execute if data entity @s {Dimension:"area:imaginary_space"} run function area:entered/imaginary_space
+execute if data entity @s {Dimension:"area:moon"} run function area:entered/moon
+execute if data entity @s {Dimension:"area:nether"} run function area:entered/nether
+execute if data entity @s {Dimension:"area:nether_dungeon"} run function area:entered/nether_dungeon
+execute if data entity @s {Dimension:"area:nether_trial"} run function area:entered/nether_trial
+execute if data entity @s {Dimension:"area:quest_area"} run function area:entered/quest_area
+execute if data entity @s {Dimension:"area:skylands"} run function area:entered/skylands
+execute if data entity @s {Dimension:"area:table_mountain"} run function area:entered/table_mountain
+execute if data entity @s {Dimension:"area:theater"} run function area:entered/theater
+execute if data entity @s {Dimension:"area:tocult_colde"} run function area:entered/tocult_colde
+execute if data entity @s {Dimension:"area:underworld"} run function area:entered/underworld
+execute if data entity @s {Dimension:"area:void"} run function area:entered/void

--- a/data/player/function/rise/none_spawn_point.mcfunction
+++ b/data/player/function/rise/none_spawn_point.mcfunction
@@ -1,0 +1,11 @@
+#> player:rise/none_spawn_point
+
+# デバッグモードならこの処理を除外
+execute if data storage main: difficult{world:"debug"} run return fail
+
+execute in area:cloudia run spawnpoint @s -1901 110 -137
+
+# 復活系の処理が控えているならテレポート処理を除外
+execute unless entity @s[tag=!HasRestoreItems,tag=!Raise] run return fail
+
+function area:jump_to/cloudia/tutorial

--- a/data/player/function/rise/none_spawn_point.mcfunction
+++ b/data/player/function/rise/none_spawn_point.mcfunction
@@ -1,7 +1,3 @@
 #> player:rise/none_spawn_point
 execute in area:cloudia run spawnpoint @s -1901 110 -137
-
-# 復活系の処理が控えているならテレポート処理を除外
-execute unless entity @s[tag=!HasRestoreItems,tag=!Raise] run return fail
-
 function area:jump_to/cloudia/tutorial

--- a/data/player/function/rise/none_spawn_point.mcfunction
+++ b/data/player/function/rise/none_spawn_point.mcfunction
@@ -1,8 +1,4 @@
 #> player:rise/none_spawn_point
-
-# デバッグモードならこの処理を除外
-execute if data storage main: difficult{world:"debug"} run return fail
-
 execute in area:cloudia run spawnpoint @s -1901 110 -137
 
 # 復活系の処理が控えているならテレポート処理を除外

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -3,6 +3,9 @@
 ## 使用するときにコメントアウトを外してください。
 # execute if score $Ticks Count matches 0 run function player:one_second
 
+### 生き返り後処理
+execute if entity @s[scores={Hunger=0..,Age=1..}] run function player:rise/
+
 ### トリガー
 execute if entity @s[scores={UseBow=1..}] run function player:trigger/use/bow
 execute if entity @s[scores={UseCrossbow=1..}] run function player:trigger/use/crossbow


### PR DESCRIPTION
レイズで復活不可能かつリスポーン地点が存在しないときにオーバーワールドの初期地点に行ってしまうバグの修正を含んでいます。
(ただし、確実な検証はレイズが復活するまでできない)