### PR TITLE
modify can_breakの処理を変更

### DIFF
--- a/data/item/function/can_break.mcfunction
+++ b/data/item/function/can_break.mcfunction
@@ -1,11 +1,5 @@
 #> item:can_break
 ###メインハンドの道具にAdv破壊適性を設定
-data modify storage item: Items set value []
-data modify storage item: Items append from entity @s SelectedItem
-# アイテム更新
-data modify storage item: Items[0].components."minecraft:can_break" set value {predicates:[{blocks:"#item:can_break"}],show_in_tooltip:false}
-data modify storage item: Items[0].components."minecraft:custom_data".CustomCanBreak set value 1b
-function item:system/shulker_box/save
-execute in area:control_area run item replace entity @s weapon.mainhand from block 2 2 2 container.0
+item modify entity @s weapon.mainhand [{"function":"set_components",components:{"minecraft:can_break":{"predicates":[{"blocks":"#item:can_break"}],show_in_tooltip:false}}},{"function":"set_custom_data",tag:"{CustomCanBreak:1b}"}]
 # トリガー解除
 advancement revoke @s only item:can_break


### PR DESCRIPTION
シュルカーボックスに移してitem replaceする方法から、
item modify 1コマンドでの処理に変更しました。