### PR TITLE
add emerald_bundle #416

### DIFF
--- a/data/item/advancement/emerald_bundle.json
+++ b/data/item/advancement/emerald_bundle.json
@@ -1,0 +1,59 @@
+{
+  "criteria": {
+    "emerald": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:emerald"
+            ],
+            "count": {
+              "min": 64
+            }
+          },
+          {
+            "items": [
+              "minecraft:bundle"
+            ],
+            "predicates": {
+              "minecraft:custom_data": "{EmeraldBundle:1b}"
+            }
+          }
+        ]
+      }
+    },
+    "megaton_emerald": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_nugget"
+            ],
+            "components": {
+              "minecraft:custom_model_data": 1
+            }
+          },
+          {
+            "items": [
+              "minecraft:bundle"
+            ],
+            "predicates": {
+              "minecraft:custom_data": "{EmeraldBundle:1b}"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "emerald",
+      "megaton_emerald"
+    ]
+  ],
+  "rewards": {
+    "function": "item:emerald_bundle/trigger"
+  }
+}

--- a/data/item/function/emerald_bundle/.mcfunction
+++ b/data/item/function/emerald_bundle/.mcfunction
@@ -1,0 +1,18 @@
+#> item:emerald_bundle/
+data modify storage item: EmeraldBundle.Success set value 0b
+data modify storage item: EmeraldBundle.Inventory set from entity @s Inventory
+
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:8b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run data modify storage item: EmeraldBundle.Bundle set from storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:8b}]
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:8b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run function item:emerald_bundle/content_check
+
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:17b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run data modify storage item: EmeraldBundle.Bundle set from storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:17b}]
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:17b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run function item:emerald_bundle/content_check
+
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:26b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run data modify storage item: EmeraldBundle.Bundle set from storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:26b}]
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:26b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run function item:emerald_bundle/content_check
+
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:35b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run data modify storage item: EmeraldBundle.Bundle set from storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:35b}]
+execute if data storage item: EmeraldBundle{Success:0b} if data storage item: EmeraldBundle.Inventory[{id:"minecraft:bundle",Slot:35b,components:{"minecraft:custom_data":{EmeraldBundle:1b}}}] run function item:emerald_bundle/content_check
+
+data remove storage item: EmeraldBundle
+advancement revoke @s only item:emerald_bundle

--- a/data/item/function/emerald_bundle/content_check.mcfunction
+++ b/data/item/function/emerald_bundle/content_check.mcfunction
@@ -1,0 +1,8 @@
+#> item:emerald_bundle/content_check
+#中身が対象のアイテムのみかチェック
+execute store result score _ Calc if data storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents"[]
+execute store result score _ _ if data storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents"[{id:"minecraft:emerald"}]
+scoreboard players operation _ Calc -= _ _
+execute store result score _ _ if data storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents"[{id:"minecraft:iron_nugget",components:{}}]
+scoreboard players operation _ Calc -= _ _
+execute if score _ Calc matches 0 run function item:emerald_bundle/count_check

--- a/data/item/function/emerald_bundle/count_check.mcfunction
+++ b/data/item/function/emerald_bundle/count_check.mcfunction
@@ -1,0 +1,6 @@
+#> item:emerald_bundle/count_check
+#残り容量をチェック
+data modify storage calc: List set value []
+data modify storage calc: List append from storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents"[].count
+execute store result score _ Calc run function calc:list/sum/x1
+execute if score _ Calc matches ..63 run function item:emerald_bundle/success

--- a/data/item/function/emerald_bundle/exchange.mcfunction
+++ b/data/item/function/emerald_bundle/exchange.mcfunction
@@ -1,0 +1,8 @@
+#> item:emerald_bundle/exchange
+#エメラルドを両替して入れる
+clear @s emerald 64
+data modify storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents" append from block 2 2 2 Items[0]
+
+#再帰処理
+scoreboard players remove _ Calc 1
+execute if score _ Calc matches 1.. run function item:emerald_bundle/exchange

--- a/data/item/function/emerald_bundle/schedule.mcfunction
+++ b/data/item/function/emerald_bundle/schedule.mcfunction
@@ -1,0 +1,4 @@
+#> item:emerald_bundle/schedule
+# @within function item:emerald_bundle/trigger
+
+execute as @a[advancements={item:emerald_bundle=true}] at @s run function item:emerald_bundle/

--- a/data/item/function/emerald_bundle/store.mcfunction
+++ b/data/item/function/emerald_bundle/store.mcfunction
@@ -2,7 +2,7 @@
 #上限を超えないようにバンドルに移す
 data modify storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents" append from storage item: EmeraldBundle.Items[0]
 execute store result score _ _ run data get storage item: EmeraldBundle.Items[0].count
-execute if score # Calc < _ _ store result storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents"[0].count int 1 run scoreboard players get # Calc
+execute if score # Calc < _ _ store result storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents"[-1].count int 1 run scoreboard players get # Calc
 execute store result storage item: EmeraldBundle.Items[0].count int -1 run scoreboard players operation # Calc -= _ _
 
 #減らしたアイテム(または空)をルート

--- a/data/item/function/emerald_bundle/store.mcfunction
+++ b/data/item/function/emerald_bundle/store.mcfunction
@@ -1,0 +1,18 @@
+#> item:emerald_bundle/store
+#上限を超えないようにバンドルに移す
+data modify storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents" append from storage item: EmeraldBundle.Items[0]
+execute store result score _ _ run data get storage item: EmeraldBundle.Items[0].count
+execute if score # Calc < _ _ store result storage item: EmeraldBundle.Bundle.components."minecraft:bundle_contents"[0].count int 1 run scoreboard players get # Calc
+execute store result storage item: EmeraldBundle.Items[0].count int -1 run scoreboard players operation # Calc -= _ _
+
+#減らしたアイテム(または空)をルート
+data modify storage item: Slot set from storage item: EmeraldBundle.Items[0].Slot
+data modify storage item: Items set from storage item: EmeraldBundle.Items
+data modify storage item: Items[0].Slot set value 0b
+execute if score # Calc matches 0.. run data modify storage item: Items[0].components."minecraft:custom_data".NoHold set value true
+function item:system/shulker_box/save
+function item:system/shulker_box/loot_to_player
+
+#再帰処理
+data remove storage item: EmeraldBundle.Items[0]
+execute if score # Calc matches 1.. if data storage item: EmeraldBundle.Items[0] run function item:emerald_bundle/store

--- a/data/item/function/emerald_bundle/success.mcfunction
+++ b/data/item/function/emerald_bundle/success.mcfunction
@@ -1,0 +1,29 @@
+#> item:emerald_bundle/success
+#残り容量を計算
+scoreboard players set # Calc 64
+scoreboard players operation # Calc -= _ Calc
+
+#エメラルドを両替して入れる
+execute store result score _ Calc run clear @s emerald 0
+scoreboard players set _ _ 64
+scoreboard players operation _ Calc /= _ _
+scoreboard players operation _ Calc < # Calc
+scoreboard players operation # Calc -= _ Calc
+execute if score _ Calc matches 1.. in area:control_area run loot replace block 2 2 2 container.0 loot item:item/iron_nugget/currency_megaton_emerald
+execute if score _ Calc matches 1.. in area:control_area run function item:emerald_bundle/exchange
+
+#メガトンエメラルドを入れる
+data modify storage item: EmeraldBundle.Items set value []
+data modify storage item: EmeraldBundle.Items append from storage item: EmeraldBundle.Inventory[{id:"minecraft:iron_nugget",components:{"minecraft:custom_model_data":1}}]
+execute if score # Calc matches 1.. if data storage item: EmeraldBundle.Items[0] run function item:emerald_bundle/store
+
+#バンドルをルート
+data modify storage item: Items set value []
+data modify storage item: Items append from storage item: EmeraldBundle.Bundle
+data modify storage item: Slot set from storage item: Items[0].Slot
+data modify storage item: Items[0].Slot set value 0b
+function item:system/shulker_box/save
+function item:system/shulker_box/loot_to_player
+
+#成功フラグを立てる
+data modify storage item: EmeraldBundle.Success set value 1b

--- a/data/item/function/emerald_bundle/trigger.mcfunction
+++ b/data/item/function/emerald_bundle/trigger.mcfunction
@@ -1,0 +1,7 @@
+#> item:emerald_bundle/trigger
+#
+# 1Tick遅れで処理
+#
+# @within advancement item:emerald_bundle
+
+schedule function item:emerald_bundle/schedule 1t


### PR DESCRIPTION
# このプルリクにはバグが含まれています！
~~じゃあ通せないな~~

* 検証用簡易エメラルドバンドル
```mcfunction
give @s bundle[minecraft:custom_model_data=2,minecraft:custom_data={EmeraldBundle:1b}]
```

## メガトンエメラルド増殖バグ
メガトンエメラルドはエメラルドバンドルに自動収納されるが、その際に増殖を起こすことがある。
1. エメラルドバンドルに1つメガトンエメラルドが入っている状態にする。
2. インベントリ上で右クリックでメガトンエメラルドを取り出し、インベントリ内に移動させる。
3. 上記の動作を繰り返す。2回に1回メガトンエメラルドが1つずつ増殖する

* 掴めている原因
	メガトンエメラルドを取り出して空にしたにもかかわらず、NBT上ではまだメガトンエメラルドが残っていることがある。

## reload時のエラー
まだメガトンエメラルドのルートテーブルが無いため、エラーが発生する。
エラーが発生する行を以下のコマンドで置き換える。
```mcfunction
execute if score _ Calc matches 1.. in area:control_area run item replace block 2 2 2 container.0 with iron_nugget[custom_model_data=1]
```