### PR TITLE
add 虚無のバンドル 初期化処理 #420

### DIFF
--- a/data/item/advancement/init_void_bundle.json
+++ b/data/item/advancement/init_void_bundle.json
@@ -1,0 +1,19 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "predicates": {
+              "minecraft:custom_data": "{VoidBundle:1b}"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "item:init_void_bundle/"
+  }
+}

--- a/data/item/function/init_void_bundle/.mcfunction
+++ b/data/item/function/init_void_bundle/.mcfunction
@@ -1,0 +1,32 @@
+#> item:init_void_bundle/
+#oh_my_datのVoidItemsを新しいものから300個バンドルに移す
+function #oh_my_dat:please
+data modify storage item: Items set value []
+data modify storage item: Items append from entity @s Inventory[{components:{"minecraft:custom_data":{VoidBundle:1b}}}]
+data modify storage item: Count set value 300
+function item:init_void_bundle/loop
+data remove storage item: Items[0].components."minecraft:custom_data".VoidItems[].Slot
+
+#VoidItemsがある場合、名前を変更
+execute if data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run data modify block 2 3 2 front_text.messages[0] set value '{"translate":"%sの虚無のバンドル","color":"light_purple","bold":true,"italic":false,"with":[{"selector":"@a[advancements={item:init_void_bundle=true}]","bold":false}]}'
+execute if data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run data modify storage item: Items[0].components."minecraft:item_name" set from block 2 3 2 front_text.messages[0]
+
+#VoidItemsがない場合、購入費をVoidItemsに入れて返金 TODO:通貨に変更 -> バンクからの購入価格に変更(v13α2)
+# execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run loot replace block 2 2 2 container.0 loot item:item/iron_nugget/currency_gigant_emerald
+execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run item replace block 2 2 2 container.0 with iron_nugget[custom_model_data=2]
+execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run data modify storage item: Items[0].components."minecraft:custom_data".VoidItems append from block 2 2 2 Items[0]
+
+#使用回数をセット
+execute store result storage item: Items[0].components."minecraft:custom_data".Skill.Count int 1 if data storage item: Items[0].components."minecraft:custom_data".VoidItems[]
+
+#未開封タグ削除
+data remove storage item: Items[0].components."minecraft:custom_data".VoidBundle
+
+#プレイヤーに渡す
+data modify storage item: Slot set from storage item: Items[0].Slot
+data modify storage item: Items[0].Slot set value 0b
+function item:system/shulker_box/save
+function item:system/shulker_box/loot_to_player
+
+#トリガー解除
+advancement revoke @s only item:init_void_bundle

--- a/data/item/function/init_void_bundle/.mcfunction
+++ b/data/item/function/init_void_bundle/.mcfunction
@@ -12,8 +12,7 @@ execute if data storage item: Items[0].components."minecraft:custom_data".VoidIt
 execute if data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run data modify storage item: Items[0].components."minecraft:item_name" set from block 2 3 2 front_text.messages[0]
 
 #VoidItemsがない場合、購入費をVoidItemsに入れて返金 TODO:通貨に変更 -> バンクからの購入価格に変更(v13α2)
-# execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run loot replace block 2 2 2 container.0 loot item:item/iron_nugget/currency_gigant_emerald
-execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run item replace block 2 2 2 container.0 with iron_nugget[custom_model_data=2]
+execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run loot replace block 2 2 2 container.0 loot item:item/iron_nugget/currency_gigant_emerald
 execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run data modify storage item: Items[0].components."minecraft:custom_data".VoidItems append from block 2 2 2 Items[0]
 
 #使用回数をセット

--- a/data/item/function/init_void_bundle/loop.mcfunction
+++ b/data/item/function/init_void_bundle/loop.mcfunction
@@ -1,0 +1,6 @@
+#> item:init_void_bundle/loop
+data modify storage item: Items[0].components."minecraft:custom_data".VoidItems append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].VoidItems[-1]
+data remove storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].VoidItems[-1]
+
+execute store result storage item: Count int 0.99999 run data get storage item: Count
+execute unless data storage item: {Count:0} if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].VoidItems[-1] run function item:init_void_bundle/loop


### PR DESCRIPTION
奈落アイテム保管もTUSBM(スキル部分)もできてないからまともなデバッグできなくてごめん！

ちゃんと名前が付与されるのと、購入金額が返却されることを確認してほしい

```mcfunction
execute unless data storage item: Items[0].components."minecraft:custom_data".VoidItems[0] in area:control_area run item replace block 2 2 2 container.0 with iron_nugget[custom_model_data=2]
```
例によってギガントエメラルドのルートテーブルがまだなので仮コード