### PR TITLE
Feature/#430/mobスポーン

### DIFF
--- a/data/entity/function/initialize_entity.mcfunction
+++ b/data/entity/function/initialize_entity.mcfunction
@@ -8,11 +8,11 @@
 execute if entity @s[type=#entity:natural_spawn,tag=] run function enemy:natural_spawn_type
 
 ### モブ召喚
-execute if entity @s[tag=Spawn] run function enemy:spawn/
+execute if entity @s[tag=Spawn] run function entity:spawn/
 
 ### モブステータス適用
 execute unless entity @s[tag=DelayedData] run data remove entity @s TicksFrozen
-execute if entity @s[tag=DelayedData] run function enemy:spawn/apply_status/
+execute if entity @s[tag=DelayedData] run function entity:spawn/apply_status/
 
 ### プレイヤー初期化
 execute if entity @s[type=player] run function player:initialize
@@ -21,7 +21,7 @@ execute if entity @s[type=player] run function player:initialize
 execute unless entity @s[type=!#entity:projectiles,tag=!DamageProjectile] run function entity:initialize_projectile
 
 ### Item to Spawn
-execute if data entity @s[type=item] Item.components."minecraft:custom_data".SpawnEntities run function enemy:spawn/item_to_spawn
+execute if data entity @s[type=item] Item.components."minecraft:custom_data".SpawnEntities run function entity:spawn/item_to_spawn
 
 ### NeverRemain削除
 kill @s[type=minecraft:item,nbt={Item:{components:{"minecraft:custom_data":{NeverRemain:true}}}}]

--- a/data/entity/function/spawn/.mcfunction
+++ b/data/entity/function/spawn/.mcfunction
@@ -16,10 +16,10 @@ data modify storage tusb_mob: MobLayers set from entity @s ArmorItems[3].compone
 ### スポナートロッコ召喚
 summon spawner_minecart ~ ~500 ~ {Tags:[OneTimeSpawner,TickingRequired],SpawnCount:1s,SpawnRange:6s,Delay:0s,MaxNearbyEntities:106s,RequiredPlayerRange:1000s,MinSpawnDelay:200s,MaxSpawnDelay:800s,NoGravity:1b,SpawnData:{entity:{id:"minecraft:experience_orb",Tags:["NotTriggerCallPassenger"],Age:6000,Passengers:[{id:"tusb_mob:creation"}]}},SpawnPotentials:[{weight:1,data:{entity:{id:"tusb_mob:empty"}}}]}
 ### ステータス適用
-execute positioned ~ ~500 ~ as @e[type=spawner_minecart,distance=..0.01] if data entity @s SpawnData.entity.Passengers[{id:"tusb_mob:creation"}] positioned ~ ~-500 ~ run function enemy:spawn/set_spawner/
+execute positioned ~ ~500 ~ as @e[type=spawner_minecart,distance=..0.01] if data entity @s SpawnData.entity.Passengers[{id:"tusb_mob:creation"}] positioned ~ ~-500 ~ run function entity:spawn/set_spawner/
 ### Count設定
 execute if data entity @s ArmorItems[3].components."minecraft:custom_data".Count positioned ~ ~500 ~ run data modify entity @e[type=spawner_minecart,limit=1,distance=..0.01,tag=Runner] SpawnCount set from entity @s ArmorItems[3].components."minecraft:custom_data".Count
-execute if data entity @s ArmorItems[3].components."minecraft:custom_data".Count run function enemy:spawn/set_spawner/count/
+execute if data entity @s ArmorItems[3].components."minecraft:custom_data".Count run function entity:spawn/set_spawner/count/
 
 execute positioned ~ ~500 ~ run tag @e[type=spawner_minecart,limit=1,distance=..0.01] remove Runner
 data remove entity @s CustomName

--- a/data/entity/function/spawn/.mcfunction
+++ b/data/entity/function/spawn/.mcfunction
@@ -6,7 +6,8 @@
 
 ### LevelとPosとRotation取得
 scoreboard players operation _ Level = @s Level
-data modify storage tusb_mob: Pos set from entity @s Pos
+execute store success score _ _ run data modify storage tusb_mob: Pos.before set from entity @s Pos
+function entity:spawn/correction_pos/
 data modify storage tusb_mob: Rotation set from entity @s Rotation
 data modify storage tusb_mob: Count set from entity @s ArmorItems[3].components."minecraft:custom_data".Count
 ### 例えば、村人が複数のタグを持っていたら？

--- a/data/entity/function/spawn/.mcfunction
+++ b/data/entity/function/spawn/.mcfunction
@@ -1,0 +1,25 @@
+#> entity:spawn/
+###################################################
+# Spawnタグを持ったエンティティに対して実行される
+# カスタムモブを召喚する
+###################################################
+
+### LevelとPosとRotation取得
+scoreboard players operation _ Level = @s Level
+data modify storage tusb_mob: Pos set from entity @s Pos
+data modify storage tusb_mob: Rotation set from entity @s Rotation
+data modify storage tusb_mob: Count set from entity @s ArmorItems[3].components."minecraft:custom_data".Count
+### 例えば、村人が複数のタグを持っていたら？
+### タグで判定するとしても、リストで保持しておいて、タグに移してから反映とかの方がいいかも
+data modify storage tusb_mob: MobLayers set from entity @s ArmorItems[3].components."minecraft:custom_data".SpawnEntities
+### スポナートロッコ召喚
+summon spawner_minecart ~ ~500 ~ {Tags:[OneTimeSpawner,TickingRequired],SpawnCount:1s,SpawnRange:6s,Delay:0s,MaxNearbyEntities:106s,RequiredPlayerRange:1000s,MinSpawnDelay:200s,MaxSpawnDelay:800s,NoGravity:1b,SpawnData:{entity:{id:"minecraft:experience_orb",Tags:["NotTriggerCallPassenger"],Age:6000,Passengers:[{id:"tusb_mob:creation"}]}},SpawnPotentials:[{weight:1,data:{entity:{id:"tusb_mob:empty"}}}]}
+### ステータス適用
+execute positioned ~ ~500 ~ as @e[type=spawner_minecart,distance=..0.01] if data entity @s SpawnData.entity.Passengers[{id:"tusb_mob:creation"}] positioned ~ ~-500 ~ run function enemy:spawn/set_spawner/
+### Count設定
+execute if data entity @s ArmorItems[3].components."minecraft:custom_data".Count positioned ~ ~500 ~ run data modify entity @e[type=spawner_minecart,limit=1,distance=..0.01,tag=Runner] SpawnCount set from entity @s ArmorItems[3].components."minecraft:custom_data".Count
+execute if data entity @s ArmorItems[3].components."minecraft:custom_data".Count run function enemy:spawn/set_spawner/count/
+
+execute positioned ~ ~500 ~ run tag @e[type=spawner_minecart,limit=1,distance=..0.01] remove Runner
+data remove entity @s CustomName
+kill @s

--- a/data/entity/function/spawn/correction_pos/.mcfunction
+++ b/data/entity/function/spawn/correction_pos/.mcfunction
@@ -1,0 +1,30 @@
+#> entity:spawn/correction_pos/
+
+# 周りが当たり判定がないブロックなら補正無視
+execute if function entity:spawn/correction_pos/check_block run return run data modify storage tusb_mob: Pos.after set from storage tusb_mob: Pos.before
+
+# 同座標の補正ならばすでに済んでいるためそのまま使用
+execute if score _ _ matches 0 run return 1
+
+# 6方向の探索をする
+# CorrectionPosマーカーからSpawnエンティティを見た方向が探索方向
+# キリのいい数字だと別の座標を指すかもしれないので余裕の0.01mを持たせる
+# 先に召喚するmerkerの方向が優先度高い
+summon marker ~-0.249 ~ ~ {Tags:[CorrectionPos]}
+summon marker ~ ~ ~0.249 {Tags:[CorrectionPos]}
+summon marker ~ ~ ~-0.249 {Tags:[CorrectionPos]}
+summon marker ~0.249 ~ ~ {Tags:[CorrectionPos]}
+summon marker ~ ~-0.49 ~ {Tags:[CorrectionPos]}
+summon marker ~ ~0.49 ~ {Tags:[CorrectionPos]}
+tag @s add CorrectTarget
+execute as @e[tag=CorrectionPos,distance=0.24..0.5] positioned as @s facing entity @n[distance=0.24..0.5,tag=CorrectTarget] feet run tp @s ~ ~ ~ ~ ~
+tag @s remove CorrectTarget
+
+# 補正開始
+scoreboard players set _ _ 0
+function entity:spawn/correction_pos/loop
+
+# 万が一召喚可能位置が見つからなければ諦める
+execute if score _ _ matches 0 run data modify storage tusb_mob: Pos.after set from storage tusb_mob: Pos.before
+
+kill @e[tag=CorrectionPos]

--- a/data/entity/function/spawn/correction_pos/check_a_point.mcfunction
+++ b/data/entity/function/spawn/correction_pos/check_a_point.mcfunction
@@ -1,0 +1,12 @@
+#> entity:spawn/correction_pos/check_a_point
+
+# すでに召喚可能位置が見つかっていれば終了
+execute if score _ _ matches 1 run return 1
+
+# 周辺のブロックを確認する
+execute if function entity:spawn/correction_pos/check_block run return run function entity:spawn/correction_pos/confirmed
+# 水平方向探索中なら左右を欲張ってみる
+execute if entity @s[x_rotation=0] positioned ^0.76 ^ ^ if function entity:spawn/correction_pos/check_block run return run function entity:spawn/correction_pos/confirmed
+execute if entity @s[x_rotation=0] positioned ^-0.76 ^ ^ if function entity:spawn/correction_pos/check_block run return run function entity:spawn/correction_pos/confirmed
+
+tp ~ ~ ~

--- a/data/entity/function/spawn/correction_pos/check_block.mcfunction
+++ b/data/entity/function/spawn/correction_pos/check_block.mcfunction
@@ -1,0 +1,15 @@
+#> entity:spawn/correction_pos/check_2
+
+#経験値オーブのHitBoxの width:0.5, height:0.5として周囲のブロックを確認する
+execute unless block ~ ~ ~ air
+execute unless block ~0.25 ~ ~ air run return fail
+execute unless block ~-0.25 ~ ~ air run return fail
+execute unless block ~ ~ ~0.25 air run return fail
+execute unless block ~ ~ ~-0.25 air run return fail
+execute unless block ~ ~0.25 ~ air run return fail
+
+# 下のブロックがフェンス系ならばここには召喚できない
+execute if block ~ ~-0.5 ~ #minecraft:fences run return fail
+execute if block ~ ~-0.5 ~ #minecraft:fence_gates run return fail
+
+return 1

--- a/data/entity/function/spawn/correction_pos/confirmed.mcfunction
+++ b/data/entity/function/spawn/correction_pos/confirmed.mcfunction
@@ -1,0 +1,6 @@
+#> entity:spawn/correction_pos/confirmed
+# 補正座標を確定させる
+scoreboard players set _ _ 1
+function calc:geometry/tp_00000
+data modify storage tusb_mob: Pos.after set from entity 0-0-0-0-0 Pos
+execute as 0-0-0-0-0 run function calc:geometry/return_marker

--- a/data/entity/function/spawn/correction_pos/loop.mcfunction
+++ b/data/entity/function/spawn/correction_pos/loop.mcfunction
@@ -1,0 +1,4 @@
+#> entity:spawn/correction_pos/loop
+# 補正予定先のポイント確認
+execute as @e[tag=CorrectionPos,distance=..1.5] at @s positioned ^ ^ ^1 run function entity:spawn/correction_pos/check_a_point
+execute if score _ _ matches 0 if entity @e[tag=CorrectionPos,distance=..1.5] run function entity:spawn/correction_pos/loop

--- a/data/entity/function/spawn/item_to_spawn.mcfunction
+++ b/data/entity/function/spawn/item_to_spawn.mcfunction
@@ -1,0 +1,6 @@
+#> entity:spawn/item_to_spawn
+#アイテムからモブを召喚する
+summon armor_stand ~ ~ ~ {Tags:[Spawn,ItemToSpawn],DeathTime:19s,NoAI:1b,Silent:1b,Invisible:1b,ArmorItems:[{},{},{},{id:"minecraft:stick",count:1,components:{"minecraft:custom_data":{CustomModelData:1,SpawnEntities:[[{Tags:[Global,Ground,Shoot,TriangularMan,Main,SpawnParticles],Level:19}]]}}}]}
+data modify entity @e[tag=ItemToSpawn,distance=0,limit=1] ArmorItems[3].components."minecraft:custom_data".SpawnEntities set from entity @s Item.components."minecraft:custom_data".SpawnEntities
+tag @e[tag=ItemToSpawn,distance=0] remove ItemToSpawn
+kill @s

--- a/data/entity/function/spawn/set_spawner/.mcfunction
+++ b/data/entity/function/spawn/set_spawner/.mcfunction
@@ -10,7 +10,7 @@ data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList
 # それぞれのモブの情報を読み取る
 data remove storage tusb_mob: Passengers
 data remove storage tusb_mob: PrevPassengers
-execute if data storage tusb_mob: MobLayers[-1] run function enemy:spawn/set_spawner/each_layer
+execute if data storage tusb_mob: MobLayers[-1] run function entity:spawn/set_spawner/each_layer
 
 ### SpawnDataに保存
 data modify entity @s SpawnData.entity.Passengers[0] set from storage tusb_mob: SpawnData

--- a/data/entity/function/spawn/set_spawner/.mcfunction
+++ b/data/entity/function/spawn/set_spawner/.mcfunction
@@ -1,0 +1,23 @@
+#> entity:spawn/set_spawner/
+###########################################################################
+# モブの(計算の要らない)基本情報を、スポナーに反映させる。
+###########################################################################
+
+# スポナーカートでOhMyDatIDを取得
+function #oh_my_dat:please
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList set value []
+
+# それぞれのモブの情報を読み取る
+data remove storage tusb_mob: Passengers
+data remove storage tusb_mob: PrevPassengers
+execute if data storage tusb_mob: MobLayers[-1] run function enemy:spawn/set_spawner/each_layer
+
+### SpawnDataに保存
+data modify entity @s SpawnData.entity.Passengers[0] set from storage tusb_mob: SpawnData
+### Pos設定
+data modify entity @s SpawnData.entity.Pos set from storage tusb_mob: Pos
+### 召喚したら消えるようにタグを付与
+data modify entity @s Tags set value [OneTimeSpawner,TickingRequired]
+
+# タグ付け
+tag @s add Runner

--- a/data/entity/function/spawn/set_spawner/.mcfunction
+++ b/data/entity/function/spawn/set_spawner/.mcfunction
@@ -15,7 +15,7 @@ execute if data storage tusb_mob: MobLayers[-1] run function enemy:spawn/set_spa
 ### SpawnDataに保存
 data modify entity @s SpawnData.entity.Passengers[0] set from storage tusb_mob: SpawnData
 ### Pos設定
-data modify entity @s SpawnData.entity.Pos set from storage tusb_mob: Pos
+data modify entity @s SpawnData.entity.Pos set from storage tusb_mob: Pos.after
 ### 召喚したら消えるようにタグを付与
 data modify entity @s Tags set value [OneTimeSpawner,TickingRequired]
 

--- a/data/entity/function/spawn/set_spawner/count/.mcfunction
+++ b/data/entity/function/spawn/set_spawner/count/.mcfunction
@@ -2,4 +2,4 @@
 data modify storage tusb_mob: DelayedData set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList
 
 execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
-execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/set_spawner/count/loop
+execute unless data storage tusb_mob: {Count:0} run function entity:spawn/set_spawner/count/loop

--- a/data/entity/function/spawn/set_spawner/count/.mcfunction
+++ b/data/entity/function/spawn/set_spawner/count/.mcfunction
@@ -1,0 +1,5 @@
+#> entity:spawn/set_spawner/count/
+data modify storage tusb_mob: DelayedData set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList
+
+execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
+execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/set_spawner/count/loop

--- a/data/entity/function/spawn/set_spawner/count/loop.mcfunction
+++ b/data/entity/function/spawn/set_spawner/count/loop.mcfunction
@@ -2,4 +2,4 @@
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList append from storage tusb_mob: DelayedData[]
 
 execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
-execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/set_spawner/count/loop
+execute unless data storage tusb_mob: {Count:0} run function entity:spawn/set_spawner/count/loop

--- a/data/entity/function/spawn/set_spawner/count/loop.mcfunction
+++ b/data/entity/function/spawn/set_spawner/count/loop.mcfunction
@@ -1,0 +1,5 @@
+#> entity:spawn/set_spawner/count/loop
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList append from storage tusb_mob: DelayedData[]
+
+execute store result storage tusb_mob: Count int 1 run data get storage tusb_mob: Count 0.999999999
+execute unless data storage tusb_mob: {Count:0} run function enemy:spawn/set_spawner/count/loop

--- a/data/entity/function/spawn/set_spawner/each_layer.mcfunction
+++ b/data/entity/function/spawn/set_spawner/each_layer.mcfunction
@@ -12,7 +12,7 @@ execute if data storage tusb_mob: Passengers run data modify storage tusb_mob: P
 # リストをリセット
 data modify storage tusb_mob: Passengers set value []
 # このレイヤーのモブを読み込む
-execute if data storage tusb_mob: MobTags[-1] run function enemy:spawn/set_spawner/each_mob
+execute if data storage tusb_mob: MobTags[-1] run function entity:spawn/set_spawner/each_mob
 
 ### Rotation設定
 data modify storage tusb_mob: Passengers[].Rotation set from storage tusb_mob: Rotation
@@ -25,4 +25,4 @@ execute unless data storage tusb_mob: MobLayers[-1] run data modify storage tusb
 ### Pos設定
 data modify entity @s SpawnData.entity.Pos set from storage tusb_mob: Pos
 ### まだ読み込んでいないタグがあれば、繰り返す
-execute if data storage tusb_mob: MobLayers[-1] run function enemy:spawn/set_spawner/each_layer
+execute if data storage tusb_mob: MobLayers[-1] run function entity:spawn/set_spawner/each_layer

--- a/data/entity/function/spawn/set_spawner/each_layer.mcfunction
+++ b/data/entity/function/spawn/set_spawner/each_layer.mcfunction
@@ -1,0 +1,28 @@
+#> entity:spawn/set_spawner/each_layer
+###########################################################################
+# モブの(計算の要らない)基本情報を、スポナーに反映させる。
+###########################################################################
+
+# tusb_mob: MobTags から、モブを召喚させるためのタグを１セット取り出す
+data modify storage tusb_mob: MobTags set from storage tusb_mob: MobLayers[-1]
+
+# tusb_mob: Passengersがすでにあったら、上に乗るモブ達なので、保存しておく
+data remove storage tusb_mob: PrevPassengers
+execute if data storage tusb_mob: Passengers run data modify storage tusb_mob: PrevPassengers set from storage tusb_mob: Passengers
+# リストをリセット
+data modify storage tusb_mob: Passengers set value []
+# このレイヤーのモブを読み込む
+execute if data storage tusb_mob: MobTags[-1] run function enemy:spawn/set_spawner/each_mob
+
+### Rotation設定
+data modify storage tusb_mob: Passengers[].Rotation set from storage tusb_mob: Rotation
+# 前の階層のモブ達を乗せる
+data modify storage tusb_mob: Passengers[-1].Passengers set from storage tusb_mob: PrevPassengers
+
+data remove storage tusb_mob: MobLayers[-1]
+### 最後のデータならスポーンデータとする
+execute unless data storage tusb_mob: MobLayers[-1] run data modify storage tusb_mob: SpawnData set from storage tusb_mob: Passengers[-1]
+### Pos設定
+data modify entity @s SpawnData.entity.Pos set from storage tusb_mob: Pos
+### まだ読み込んでいないタグがあれば、繰り返す
+execute if data storage tusb_mob: MobLayers[-1] run function enemy:spawn/set_spawner/each_layer

--- a/data/entity/function/spawn/set_spawner/each_mob.mcfunction
+++ b/data/entity/function/spawn/set_spawner/each_mob.mcfunction
@@ -53,4 +53,4 @@ data modify storage tusb_mob: Passengers prepend from storage tusb_mob: SpawnDat
 
 ### まだ読み込んでいないタグがあれば、繰り返す
 data remove storage tusb_mob: MobTags[-1]
-execute if data storage tusb_mob: MobTags[-1] run function enemy:spawn/set_spawner/each_mob
+execute if data storage tusb_mob: MobTags[-1] run function entity:spawn/set_spawner/each_mob

--- a/data/entity/function/spawn/set_spawner/each_mob.mcfunction
+++ b/data/entity/function/spawn/set_spawner/each_mob.mcfunction
@@ -17,7 +17,7 @@ data modify storage tusb_mob: "遅延ステータス"."ステータス" set valu
 function #entity:spawn_data
 
 #召喚時演出
-execute if entity @s[tag=SpawnParticles] run function makeup:enemy/spawn
+execute if entity @s[tag=SpawnParticles] run function makeup:entity/spawn
 
 #モブのレベルを引き継ぐ
 execute if score _ Level matches 1.. store result storage tusb_mob: MobTags[-1].Level int 1 run scoreboard players get _ Level

--- a/data/entity/function/spawn/set_spawner/each_mob.mcfunction
+++ b/data/entity/function/spawn/set_spawner/each_mob.mcfunction
@@ -14,7 +14,7 @@ data remove storage tusb_mob: "遅延ステータス"
 data modify storage tusb_mob: "遅延ステータス"."ステータス" set value {"炎属性値":100,"氷属性値":100,"雷属性値":100,"光属性値":100,"闇属性値":100}
 
 # タグに応じて、データを取得する
-function settings:enemy/
+function #entity:spawn_data
 
 #召喚時演出
 execute if entity @s[tag=SpawnParticles] run function makeup:enemy/spawn

--- a/data/entity/function/spawn/set_spawner/each_mob.mcfunction
+++ b/data/entity/function/spawn/set_spawner/each_mob.mcfunction
@@ -1,0 +1,56 @@
+#> entity:spawn/set_spawner/each_mob
+###########################################################################
+# モブの(計算の要らない)基本情報を、スポナーに反映させる。
+###########################################################################
+
+# tusb_mob: MobTags から、モブを召喚させるためのタグを１セット取り出す
+data modify entity @s Tags set from storage tusb_mob: MobTags[-1].Tags
+
+#データを初期化
+data remove storage tusb_mob: "即時ステータス"
+data remove storage tusb_mob: "遅延ステータス"
+
+# 属性値デフォルト
+data modify storage tusb_mob: "遅延ステータス"."ステータス" set value {"炎属性値":100,"氷属性値":100,"雷属性値":100,"光属性値":100,"闇属性値":100}
+
+# タグに応じて、データを取得する
+function settings:enemy/
+
+#召喚時演出
+execute if entity @s[tag=SpawnParticles] run function makeup:enemy/spawn
+
+#モブのレベルを引き継ぐ
+execute if score _ Level matches 1.. store result storage tusb_mob: MobTags[-1].Level int 1 run scoreboard players get _ Level
+
+# tusb_mob: SpawnDataを初期化する
+data modify storage tusb_mob: SpawnData set value {attributes:[{id:"minecraft:generic.movement_speed"},{id:"minecraft:generic.knockback_resistance"},{id:"minecraft:generic.attack_knockback"}],Passengers:[]}
+
+# OhMyDatIDを保存
+execute store result storage tusb_mob: SpawnData.TicksFrozen int 1 run scoreboard players get @s OhMyDatID
+
+# 即時ステータスを反映させる
+data modify storage tusb_mob: SpawnData merge from storage tusb_mob: "即時ステータス"."ベース"
+data modify storage tusb_mob: SpawnData merge from storage tusb_mob: "即時ステータス"."見た目"
+execute if data storage tusb_mob: SpawnData{Tags:[Enemy]} unless data storage tusb_mob: SpawnData.Team run data modify storage tusb_mob: SpawnData.Team set value "Enemy"
+execute if data storage tusb_mob: SpawnData{Team:"None"} run data remove storage tusb_mob: SpawnData.Team
+data modify storage tusb_mob: SpawnData.attributes[{id:"minecraft:generic.follow_range"}].base set from storage tusb_mob: "即時ステータス"."最大感知範囲"
+data modify storage tusb_mob: SpawnData.attributes[{id:"minecraft:generic.movement_speed"}].base set from storage tusb_mob: "即時ステータス"."基本移動力"
+data modify storage tusb_mob: SpawnData.attributes[{id:"minecraft:generic.knockback_resistance"}].base set from storage tusb_mob: "即時ステータス"."ノックバック耐性"
+data modify storage tusb_mob: SpawnData.attributes[{id:"minecraft:generic.attack_knockback"}].base set from storage tusb_mob: "即時ステータス"."ノックバック力"
+
+# 遅延ステータスを保存する
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList append value {}
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList[-1].Level set from storage tusb_mob: MobTags[-1].Level
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList[-1]."遅延ステータス" set from storage tusb_mob: "遅延ステータス"
+execute unless data storage tusb_mob: "即時ステータス"."ベース"{Tags:[DelayedData]} run data remove storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList[-1]
+
+# 親IDを保存する
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DelayedDataList[-1].ParentID set from storage tusb_mob: MobTags[-1].ParentID
+
+
+### 上のモブをリストに追加する
+data modify storage tusb_mob: Passengers prepend from storage tusb_mob: SpawnData
+
+### まだ読み込んでいないタグがあれば、繰り返す
+data remove storage tusb_mob: MobTags[-1]
+execute if data storage tusb_mob: MobTags[-1] run function enemy:spawn/set_spawner/each_mob

--- a/data/entity/function/tick.mcfunction
+++ b/data/entity/function/tick.mcfunction
@@ -6,6 +6,9 @@ execute if score $Ticks Count matches 0 run function entity:one_second
 ### エンティティ初期化
 execute as @e[tag=!Initialized] at @s run function entity:initialize_entity
 
+### 召喚済み単回スポナー削除
+kill @e[tag=OneTimeSpawner,nbt={SpawnData:{entity:{id:"tusb_mob:empty"}}}]
+
 ### エンティティPortalCooldownチェック
 execute as @e[tag=CooldownRequired,nbt={PortalCooldown:0}] at @s run function entity:cooldown
 

--- a/data/entity/tags/function/spawn_data.json
+++ b/data/entity/tags/function/spawn_data.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "settings:entity/"
+  ]
+}

--- a/data/makeup/function/entity/spawn.mcfunction
+++ b/data/makeup/function/entity/spawn.mcfunction
@@ -1,0 +1,2 @@
+#> makeup:entity/spawn
+particle minecraft:poof ~ ~1 ~ 0.5 0.7 0.5 0 5


### PR DESCRIPTION
モブの呼び出しを再実装しました。基本的な動作はv13α2までと同様です。

#179 
こちらのバグ修正として、ブロックに埋まっていて召喚不可能な場合に、召喚位置をずらす処理を追加しました。

Mobデータの読み取り口を `settings:enemy/` で直接指定する方式から、`#entity:spawn_data`に変更しました。