### PR TITLE
パーティクル表示抑制機能を追加

### DIFF
--- a/data/player/function/particle/update_tag.mcfunction
+++ b/data/player/function/particle/update_tag.mcfunction
@@ -4,7 +4,7 @@
 ## パーティクル表示タグを削除
 tag @s remove ShowParticles
 
-execute store result score _ Calc run scoreboard players operation _ _ = $Tick Count
+execute store result score _ Calc run scoreboard players operation _ _ = $Ticks Count
 
 scoreboard players set _ ParticleDenom 6
 scoreboard players operation _ _ %= _ ParticleDenom

--- a/data/player/function/particle/update_tag.mcfunction
+++ b/data/player/function/particle/update_tag.mcfunction
@@ -2,20 +2,20 @@
 ### パーティクル表示タグ更新
 
 ## パーティクル表示タグを削除
-tag @a remove ShowParticles
+tag @s remove ShowParticles
 
 execute store result score _ Calc run scoreboard players operation _ _ = $Tick Count
 
 scoreboard players set _ ParticleDenom 6
 scoreboard players operation _ _ %= _ ParticleDenom
-execute if score _ _ matches 0 run tag @a[scores={ParticleDenom=5}] add ShowParticles
+execute if score _ _ matches 0 run tag @s[scores={ParticleDenom=5}] add ShowParticles
 scoreboard players set _ ParticleDenom 3
 scoreboard players operation _ _ %= _ ParticleDenom
-execute if score _ _ matches 0 run tag @a[scores={ParticleDenom=3}] add ShowParticles
+execute if score _ _ matches 0 run tag @s[scores={ParticleDenom=3}] add ShowParticles
 scoreboard players set _ ParticleDenom 4
 scoreboard players operation _ Calc %= _ ParticleDenom
-execute if score _ Calc matches 0 run tag @a[scores={ParticleDenom=4}] add ShowParticles
+execute if score _ Calc matches 0 run tag @s[scores={ParticleDenom=4}] add ShowParticles
 scoreboard players set _ ParticleDenom 2
 scoreboard players operation _ Calc %= _ ParticleDenom
-execute if score _ Calc matches 0 run tag @a[scores={ParticleDenom=2}] add ShowParticles
-execute as @a unless score @s ParticleDenom matches 2.. run tag @s add ShowParticles
+execute if score _ Calc matches 0 run tag @s[scores={ParticleDenom=2}] add ShowParticles
+execute unless score @s ParticleDenom matches 2.. run tag @s add ShowParticles

--- a/data/player/function/particle/update_tag.mcfunction
+++ b/data/player/function/particle/update_tag.mcfunction
@@ -1,0 +1,21 @@
+
+### パーティクル表示タグ更新
+
+## パーティクル表示タグを削除
+tag @a remove ShowParticles
+
+execute store result score _ Calc run scoreboard players operation _ _ = $Tick Count
+
+scoreboard players set _ ParticleDenom 6
+scoreboard players operation _ _ %= _ ParticleDenom
+execute if score _ _ matches 0 run tag @a[scores={ParticleDenom=5}] add ShowParticles
+scoreboard players set _ ParticleDenom 3
+scoreboard players operation _ _ %= _ ParticleDenom
+execute if score _ _ matches 0 run tag @a[scores={ParticleDenom=3}] add ShowParticles
+scoreboard players set _ ParticleDenom 4
+scoreboard players operation _ Calc %= _ ParticleDenom
+execute if score _ Calc matches 0 run tag @a[scores={ParticleDenom=4}] add ShowParticles
+scoreboard players set _ ParticleDenom 2
+scoreboard players operation _ Calc %= _ ParticleDenom
+execute if score _ Calc matches 0 run tag @a[scores={ParticleDenom=2}] add ShowParticles
+execute as @a unless score @s ParticleDenom matches 2.. run tag @s add ShowParticles

--- a/data/player/function/particle/update_tag.mcfunction
+++ b/data/player/function/particle/update_tag.mcfunction
@@ -1,4 +1,4 @@
-
+#> player:particle/update_tag
 ### パーティクル表示タグ更新
 
 ## パーティクル表示タグを削除

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -4,7 +4,7 @@
 # execute if score $Ticks Count matches 0 run function player:one_second
 
 ###パーティクル表示判定
-function main:particle/update_tag
+function player:particle/update_tag
 
 ### 生き返り後処理
 execute if entity @s[scores={Hunger=0..,Age=1..}] run function player:rise/

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -3,6 +3,9 @@
 ## 使用するときにコメントアウトを外してください。
 # execute if score $Ticks Count matches 0 run function player:one_second
 
+###パーティクル表示判定
+function main:particle/update_tag
+
 ### 生き返り後処理
 execute if entity @s[scores={Hunger=0..,Age=1..}] run function player:rise/
 


### PR DESCRIPTION
## チケットURL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合はNO-ISSUE -->
GH-505
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
パーティクル抑制機能を追加しました。
設定されたtickごとにパーティクルが表示されるようになります。
例：1/3なら、3tickごとに表示される
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* `main/functions` -> `player/function`
* 全体向け処理から個人向け処理へ変更
* `$Tick` -> `$Ticks`
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
- PR
  - [x] PRのタイトルはわかり易い名前が設定されていますか?(日本語でも可)
  - [x] PRの必須項目はすべて記載していますか?
  - [x] PRの必要ない項目は削除していますか?
  - [x] PRの内容と変更内容は一致していますか?
    - 1機能=1PRであるべきです。1機能の途中でも問題ありません
- Commit
  - [x] Commitメッセージはルール通りですか?
    - コミットメッセージの先頭に`[Add|Delete|Modify|Fix|Refactor|Move]`等の動詞の原形を追加してください。([参考](https://www.tam-tam.co.jp/tipsnote/program/post16686.html)) ([参考2](https://note.com/haru_notes/n/n3d9c406e9ac6))
    - コミットメッセージの説明には`GH-〇〇`でチケット番号をつけてください  
      (チケットが存在しない場合は`NO-ISSUE`にしてください
    - マージコミットの場合はこの限りではありません
    <!-- 
    例: GH-100 Add 特殊演出を追加  
    例: NO-ISSUE Move フォルダを〇〇へ移動
    ブランチ名のようにfeatureやfixは必要ありません
    -->
  - [x] コミットの粒度は適切ですか?
    - 1コミット=1要素(1ロジック)の変更であるべきです  
    <!-- 
    例: ファイル移動してから内容変更したい場合は2回コミット分けるべきです  
    例: デバッグメッセージ表示と新たなロジック追加した場合も2回コミット分けるべきです -->
- Branch
  - [x] ブランチの名前は正しいですか?
    - ブランチ名先頭は`feature/[簡単な説明]` か `fix/[簡単な説明]` の何れかであるべきです
    - 簡単な説明は`英語であるべきです`(不具合発生するので)
  - [x] ブランチの向き、切り先は正しいですか?
<!-- ここから上は削除しないでください -->
