### PR TITLE
スキル向けの装備情報変換処理が動作しないバグを修正

### DIFF
--- a/data/skill/function/equipments_to_items.mcfunction
+++ b/data/skill/function/equipments_to_items.mcfunction
@@ -12,4 +12,4 @@
 
 data modify storage calc: Array.reverse.Input set from storage item: Equipments
 function calc:array/reverse/
-data modify storage item Items set from storage calc: Array.reverse.Output
+data modify storage item: Items set from storage calc: Array.reverse.Output

--- a/data/skill/function/equipments_to_items.mcfunction
+++ b/data/skill/function/equipments_to_items.mcfunction
@@ -10,6 +10,7 @@
 # 順番：防具 → オフハンド → メインハンド
 #
 
+data modify storage item: Items set value []
 data modify storage calc: Array.reverse.Input set from storage item: Equipments
 function calc:array/reverse/
 data modify storage item: Items set from storage calc: Array.reverse.Output


### PR DESCRIPTION
## チケットURL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合はNO-ISSUE -->
NO-ISSUE
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
* 対応内容
装備情報変換処理で正しい処理の結果を得られないバグを修正しました。
装備がない状態で変換処理をしたときに、item: Itemsの中身が更新されないバグを修正しました。

* 対応背景
装備が正しく変換されなければ、スキルを実行することができないため
装備を持たずにスキルを発動したときに前回の`item: Items`が残ってしまうので、意図しない処理が実行されてしまう。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* ストレージの名前空間を修正
	`item` -> `item:`
* ストレージ `item: Items`を空のListで初期化するように修正。
## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
- PR
  - [x] PRのタイトルはわかり易い名前が設定されていますか?(日本語でも可)
  - [x] PRの必須項目はすべて記載していますか?
  - [x] PRの必要ない項目は削除していますか?
  - [x] PRの内容と変更内容は一致していますか?
    - 1機能=1PRであるべきです。1機能の途中でも問題ありません
- Commit
  - [x] Commitメッセージはルール通りですか?
    - コミットメッセージの先頭に`[Add|Delete|Modify|Fix|Refactor|Move]`等の動詞の原形を追加してください。([参考](https://www.tam-tam.co.jp/tipsnote/program/post16686.html)) ([参考2](https://note.com/haru_notes/n/n3d9c406e9ac6))
    - コミットメッセージの説明には`GH-〇〇`でチケット番号をつけてください  
      (チケットが存在しない場合は`NO-ISSUE`にしてください
    - マージコミットの場合はこの限りではありません
    <!-- 
    例: GH-100 Add 特殊演出を追加  
    例: NO-ISSUE Move フォルダを〇〇へ移動
    ブランチ名のようにfeatureやfixは必要ありません
    -->
  - [x] コミットの粒度は適切ですか?
    - 1コミット=1要素(1ロジック)の変更であるべきです  
    <!-- 
    例: ファイル移動してから内容変更したい場合は2回コミット分けるべきです  
    例: デバッグメッセージ表示と新たなロジック追加した場合も2回コミット分けるべきです -->
- Branch
  - [x] ブランチの名前は正しいですか?
    - ブランチ名先頭は`feature/[簡単な説明]` か `fix/[簡単な説明]` の何れかであるべきです
    - 簡単な説明は`英語であるべきです`(不具合発生するので)
  - [x] ブランチの向き、切り先は正しいですか?
<!-- ここから上は削除しないでください -->
