### PR TITLE
プレイヤーのトリガー処理でアイテムのコンポーネント化に未対応だったものを修正

### DIFF
--- a/data/player/function/trigger/sneak.mcfunction
+++ b/data/player/function/trigger/sneak.mcfunction
@@ -12,7 +12,7 @@ execute if score @s[gamemode=!spectator] SneakTime matches 3 run function skill:
 execute if score @s SneakTime matches ..2 run scoreboard players reset @s SneakTrigger
 
 # スニーク解除時スキル
-execute if score @s[gamemode=!spectator] SneakTime matches 2 if data entity @s[predicate=skill:trigger/weapon/] Inventory[{tag:{Skill:{Trigger:"剣を持った状態でスニーク解除"}}}] run function skill:trigger/after_sneak_skill
+execute if score @s[gamemode=!spectator] SneakTime matches 2 if data entity @s[predicate=skill:trigger/weapon/] Inventory[{components:{"minecraft:custom_data":{Skill:{Trigger:"剣を持った状態でスニーク解除"}}}}] run function skill:trigger/after_sneak_skill
 
 # 近くに墓がある場合、墓からものを取り出す
     execute if entity @s[scores={Age=1..},predicate=entity:player] if score @s SneakTime matches 3 as @e[type=item_display,tag=Tomb,distance=..1] at @s run function player:death_item_drop/tomb_drop

--- a/data/player/function/trigger/use/bow.mcfunction
+++ b/data/player/function/trigger/use/bow.mcfunction
@@ -12,8 +12,8 @@ execute if score @s PiercingAim matches 1.. run function skill:act/hunter/pierci
 #スキル
 function skill:equipments_to_items
 data remove storage item: Item
-data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"弓を構えて矢を撃つ"}}}]
-execute if data storage item: Item.tag.Skill{Trigger:"弓を構えて矢を撃つ"} run function skill:practice/
+data modify storage item: Item set from storage item: Items[{components:{"minecraft:custom_data":{Skill:{Trigger:"弓を構えて矢を撃つ"}}}}]
+execute if data storage item: Item.components."minecraft:custom_data".Skill{Trigger:"弓を構えて矢を撃つ"} run function skill:practice/
 #ダメージと装備を保存
 execute as @e[type=#minecraft:impact_projectiles,tag=!Initialized,distance=..2] run function player:trigger/projectile/save
 #トリガーリセット

--- a/data/player/function/trigger/use/carrot_on_a_stick.mcfunction
+++ b/data/player/function/trigger/use/carrot_on_a_stick.mcfunction
@@ -4,7 +4,7 @@ function player:load_equipments
 #スキル
 function skill:equipments_to_items
 data remove storage item: Item
-data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"手に持って右クリック"}}}]
-execute if data storage item: Item.tag.Skill{Trigger:"手に持って右クリック"} run function skill:practice/
+data modify storage item: Item set from storage item: Items[{components:{"minecraft:custom_data":{Skill:{Trigger:"手に持って右クリック"}}}}]
+execute if data storage item: Item.components."minecraft:custom_data".Skill{Trigger:"手に持って右クリック"} run function skill:practice/
 #トリガーリセット
 scoreboard players reset @s UseCarrotStick

--- a/data/player/function/trigger/use/crossbow.mcfunction
+++ b/data/player/function/trigger/use/crossbow.mcfunction
@@ -12,8 +12,8 @@ execute if score @s PiercingAim matches 1.. run function skill:act/hunter/pierci
 #スキル
 function skill:equipments_to_items
 data remove storage item: Item
-data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"クロスボウを構えて矢を撃つ"}}}]
-execute if data storage item: Item.tag.Skill{Trigger:"クロスボウを構えて矢を撃つ"} run function skill:practice/
+data modify storage item: Item set from storage item: Items[{components:{"minecraft:custom_data":{Skill:{Trigger:"クロスボウを構えて矢を撃つ"}}}}]
+execute if data storage item: Item.components."minecraft:custom_data".Skill{Trigger:"クロスボウを構えて矢を撃つ"} run function skill:practice/
 #ダメージと装備を保存
 execute as @e[type=#minecraft:impact_projectiles,tag=!Initialized,distance=..2] run function player:trigger/projectile/save
 #トリガーリセット

--- a/data/player/function/trigger/use/shield.mcfunction
+++ b/data/player/function/trigger/use/shield.mcfunction
@@ -7,7 +7,7 @@ function player:load_equipments
 ### スキル
 function skill:equipments_to_items
 data remove storage item: Item
-data modify storage item: Item set from storage item: Items[{tag:{Skill:{Trigger:"盾で攻撃を防ぐ"}}}]
-execute if data storage item: Item.tag.Skill{Trigger:"盾で攻撃を防ぐ"} run function skill:practice/
+data modify storage item: Item set from storage item: Items[{components:{"minecraft:custom_data":{Skill:{Trigger:"盾で攻撃を防ぐ"}}}}]
+execute if data storage item: Item.components."minecraft:custom_data".Skill{Trigger:"盾で攻撃を防ぐ"} run function skill:practice/
 #トリガーリセット
 advancement revoke @s only player:trigger/use/shield


### PR DESCRIPTION
## チケットURL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合はNO-ISSUE -->
NO-ISSUE
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
* 対応内容
アイテムのNBTパスがコンポーネント化以前のものだったのを修正しました

* 対応背景
スキルを実行するアイテムを取得することができないため、スキルを実行できない状態になっていたから。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* アイテムのコンポーネント化
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
- PR
  - [x] PRのタイトルはわかり易い名前が設定されていますか?(日本語でも可)
  - [x] PRの必須項目はすべて記載していますか?
  - [x] PRの必要ない項目は削除していますか?
  - [x] PRの内容と変更内容は一致していますか?
    - 1機能=1PRであるべきです。1機能の途中でも問題ありません
- Commit
  - [x] Commitメッセージはルール通りですか?
    - コミットメッセージの先頭に`[Add|Delete|Modify|Fix|Refactor|Move]`等の動詞の原形を追加してください。([参考](https://www.tam-tam.co.jp/tipsnote/program/post16686.html)) ([参考2](https://note.com/haru_notes/n/n3d9c406e9ac6))
    - コミットメッセージの説明には`GH-〇〇`でチケット番号をつけてください  
      (チケットが存在しない場合は`NO-ISSUE`にしてください
    - マージコミットの場合はこの限りではありません
    <!-- 
    例: GH-100 Add 特殊演出を追加  
    例: NO-ISSUE Move フォルダを〇〇へ移動
    ブランチ名のようにfeatureやfixは必要ありません
    -->
  - [x] コミットの粒度は適切ですか?
    - 1コミット=1要素(1ロジック)の変更であるべきです  
    <!-- 
    例: ファイル移動してから内容変更したい場合は2回コミット分けるべきです  
    例: デバッグメッセージ表示と新たなロジック追加した場合も2回コミット分けるべきです -->
- Branch
  - [x] ブランチの名前は正しいですか?
    - ブランチ名先頭は`feature/[簡単な説明]` か `fix/[簡単な説明]` の何れかであるべきです
    - 簡単な説明は`英語であるべきです`(不具合発生するので)
  - [x] ブランチの向き、切り先は正しいですか?
<!-- ここから上は削除しないでください -->
