### PR TITLE
任意のアイテムに任意のデータを付与できるバグを修正

### DIFF
--- a/data/item/functions/custom_can_place_on/loop.mcfunction
+++ b/data/item/functions/custom_can_place_on/loop.mcfunction
@@ -9,7 +9,6 @@ data modify storage item: Items[0].tag.CanPlaceOn set value ["#item:can_place_on
 data modify storage item: Items[0].tag.HideFlags set value 16
 data modify storage item: Items[0].tag.CustomCanPlaceOn set value 1b
 data modify storage item: Items[0].tag.display.Lore append value '{"translate":"アドベンチャーエリアで設置可能","italic":false,"color":"gray"}'
-item modify entity @s weapon.mainhand item:storage/item
 function item:system/shulker_box/save
 #プレイヤーにルート
 data modify storage item: Slot set from storage item: CanPlaceOn[-1].Slot


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
NO-ISSUE
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->

## 対応内容・対応背景・妥協点<!-- 必須 -->
Adv設置可能アイテムにAdv設置属性を付与する処理が実行されたときに、メインハンドに持っている任意のアイテムに、直前に設定されていた`item: Item`のデータを付与することができるバグを修正しました。
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->

## やったこと<!-- 必須 -->
* 余計なコードを削除
<!-- このPR内でやったことを書く -->

<!-- ここから下は削除しないでください -->

### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)

- Pull Request

  - [x] PR のタイトルはわかりやすい名前が設定されていますか?(日本語でも可)
  - [x] PR の必須項目はすべて記載していますか?
  - [x] PR の必要ない項目は削除していますか?
  - [x] PR の内容と変更内容は一致していますか?
    - 1 機能=1PR であるべきです。1 機能の途中でも問題ありません

- Commit

  - [x] Commit メッセージはルール通りですか?
    - コミットメッセージの先頭に`[Add|Delete|Modify|Fix|Refactor|Move]`
      等の動詞の原形を追加してください。  
      ([参考](https://www.tam-tam.co.jp/tipsnote/program/post16686.html))  
      ([参考 2](https://note.com/haru_notes/n/n3d9c406e9ac6))
    - コミットメッセージの説明には`GH-〇〇`でチケット番号をつけてください  
      (チケットが存在しない場合は`NO-ISSUE`にしてください)
    - マージコミットの場合はこの限りではありません
    <!--
      例: GH-100 Add 特殊演出を追加
      例: NO-ISSUE Move フォルダを〇〇へ移動
      ブランチ名のようにfeatureやfixは必要ありません
    -->
  - [x] コミットの粒度は適切ですか?
    - 1 コミット=1 要素(1 ロジック)の変更であるべきです
    <!--
      例: ファイル移動してから内容変更したい場合は2回コミット分けるべきです
      例: デバッグメッセージ表示と新たなロジック追加した場合も2回コミット分けるべきです
    -->

- Branch
  - [x] ブランチの名前は正しいですか?
    - ブランチ名先頭は`feature/[簡単な説明]` または `fix/[簡単な説明]` であるべきです
    - 簡単な説明は英語であるべきです(不具合発生するので)
  - [x] ブランチの向き、切り先は正しいですか?

<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
