### PR TITLE
チュートリアル中に死んだときにチュートリアルエリア外に復活する問題を修正(1-21-1)

### DIFF
--- a/data/tutorial_alpha/functions/system/respawn.mcfunction
+++ b/data/tutorial_alpha/functions/system/respawn.mcfunction
@@ -1,2 +1,5 @@
-execute if data entity @s[y=0,dy=255] {Dimension:"area:debug_room"} run spawnpoint @s ~ ~ ~
+# デフォルトとしてチュートリアル初期地点に復活
+spawnpoint @s -4291 33 808
+# 範囲内かつめり込んでなければ死んだ地点に復活する
+execute if data entity @s[y=0,dy=255] {Dimension:"area:debug_room"} if block ~ ~ ~ #block:no_collision run spawnpoint @s ~ ~ ~
 execute unless data entity @s {Dimension:"area:debug_room"} run function tutorial_alpha:system/issue_178


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
GH-178
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->

## 対応内容・対応背景・妥協点<!-- 必須 -->
チュートリアル受講中に死んだときにまれにチュートリアルエリア外に出ることがある。このときに以前のアイテムが復活しなくなってしまう。
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->

## やったこと<!-- 必須 -->
* デフォルト復活地点を追加し、条件に合致したときに限り死亡した地点に復活するように修正
<!-- このPR内でやったことを書く -->

<!-- ここから下は削除しないでください -->

### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)

- Pull Request

  - [x] PR のタイトルはわかりやすい名前が設定されていますか?(日本語でも可)
  - [x] PR の必須項目はすべて記載していますか?
  - [x] PR の必要ない項目は削除していますか?
  - [x] PR の内容と変更内容は一致していますか?
    - 1 機能=1PR であるべきです。1 機能の途中でも問題ありません

- Commit

  - [x] Commit メッセージはルール通りですか?
    - コミットメッセージの先頭に`[Add|Delete|Modify|Fix|Refactor|Move]`
      等の動詞の原形を追加してください。  
      ([参考](https://www.tam-tam.co.jp/tipsnote/program/post16686.html))  
      ([参考 2](https://note.com/haru_notes/n/n3d9c406e9ac6))
    - コミットメッセージの説明には`GH-〇〇`でチケット番号をつけてください  
      (チケットが存在しない場合は`NO-ISSUE`にしてください)
    - マージコミットの場合はこの限りではありません
    <!--
      例: GH-100 Add 特殊演出を追加
      例: NO-ISSUE Move フォルダを〇〇へ移動
      ブランチ名のようにfeatureやfixは必要ありません
    -->
  - [x] コミットの粒度は適切ですか?
    - 1 コミット=1 要素(1 ロジック)の変更であるべきです
    <!--
      例: ファイル移動してから内容変更したい場合は2回コミット分けるべきです
      例: デバッグメッセージ表示と新たなロジック追加した場合も2回コミット分けるべきです
    -->

- Branch
  - [x] ブランチの名前は正しいですか?
    - ブランチ名先頭は`feature/[簡単な説明]` または `fix/[簡単な説明]` であるべきです
    - 簡単な説明は英語であるべきです(不具合発生するので)
  - [x] ブランチの向き、切り先は正しいですか?

<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
