### PR TITLE
復活系スキルで復活地点を失ったときにオーバーワールドで復活するバグを修正(1-21-1)

### DIFF
--- a/data/skill/functions/act/white_mage/araise/raise_check.mcfunction
+++ b/data/skill/functions/act/white_mage/araise/raise_check.mcfunction
@@ -9,6 +9,8 @@ data modify storage tusb_player: Raise set from storage oh_my_dat: _[-4][-4][-4]
 execute store result score _ _ run data get storage tusb_player: Raise.Pos[1] 100
 execute if score _ _ matches -5000.. run function skill:act/white_mage/araise/raised
 execute unless score _ _ matches -5000.. run tellraw @s [{"translate":"帰還地点は消滅していた…。","color": "yellow"}]
+# 奈落かつスポーンポイントが無いならば初期地点へテレポートする
+execute unless score _ _ matches -5000.. unless data entity @s SpawnForced run function player:rise/none_spawn_point
 
 # タグ削除
 tag @s remove Raise


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
GH-398
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->

## 対応内容・対応背景・妥協点<!-- 必須 -->
ベッドを壊してリスポーン地点を失ってから、レイズで奈落に落ちたとき帰還地点を失う。
そのときにオーバーワールドへ復活してしまう。そのバグを修正しました。

<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->

## やったこと<!-- 必須 -->
* 奈落かつ復活地点が無い時に初期リスポーン地点で復活するように処理を追加
<!-- このPR内でやったことを書く -->

<!-- ここから下は削除しないでください -->

### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)

- Pull Request

  - [x] PR のタイトルはわかりやすい名前が設定されていますか?(日本語でも可)
  - [x] PR の必須項目はすべて記載していますか?
  - [x] PR の必要ない項目は削除していますか?
  - [x] PR の内容と変更内容は一致していますか?
    - 1 機能=1PR であるべきです。1 機能の途中でも問題ありません

- Commit

  - [x] Commit メッセージはルール通りですか?
    - コミットメッセージの先頭に`[Add|Delete|Modify|Fix|Refactor|Move]`
      等の動詞の原形を追加してください。  
      ([参考](https://www.tam-tam.co.jp/tipsnote/program/post16686.html))  
      ([参考 2](https://note.com/haru_notes/n/n3d9c406e9ac6))
    - コミットメッセージの説明には`GH-〇〇`でチケット番号をつけてください  
      (チケットが存在しない場合は`NO-ISSUE`にしてください)
    - マージコミットの場合はこの限りではありません
    <!--
      例: GH-100 Add 特殊演出を追加
      例: NO-ISSUE Move フォルダを〇〇へ移動
      ブランチ名のようにfeatureやfixは必要ありません
    -->
  - [x] コミットの粒度は適切ですか?
    - 1 コミット=1 要素(1 ロジック)の変更であるべきです
    <!--
      例: ファイル移動してから内容変更したい場合は2回コミット分けるべきです
      例: デバッグメッセージ表示と新たなロジック追加した場合も2回コミット分けるべきです
    -->

- Branch
  - [x] ブランチの名前は正しいですか?
    - ブランチ名先頭は`feature/[簡単な説明]` または `fix/[簡単な説明]` であるべきです
    - 簡単な説明は英語であるべきです(不具合発生するので)
  - [x] ブランチの向き、切り先は正しいですか?

<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
