### PR TITLE
[feature] 砂利のルートテーブルを一部調整して序盤の資材不足の緩和 #685

### DIFF
--- a/data/item/loot_tables/group/block/gravel.json
+++ b/data/item/loot_tables/group/block/gravel.json
@@ -11,7 +11,7 @@
         {
           "weight": 1800,
           "type": "minecraft:item",
-          "name": "minecraft:dead_bush",
+          "name": "minecraft:stick",
           "functions": [
             {
               "function": "minecraft:set_count",
@@ -103,6 +103,11 @@
           "weight": 80,
           "type": "loot_table",
           "name": "item:item/carrot_on_a_stick/calling_grass"
+        },
+        {
+          "weight": 80,
+          "type": "minecraft:item",
+          "name": "minecraft:dark_oak_planks"
         },
         {
           "weight": 75,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
https://github.com/TUSB/TheUnusualSkyBlock/issues/685

## 対応内容・対応背景・妥協点<!-- 必須 -->

#685 の通り、序盤の資材の緩和処置。

## やったこと<!-- 必須 -->

砂利のルートテーブル内の枯れ木を棒に変更し、ダークオークがドロップするように追加。

<!-- ここから下は削除しないでください -->

### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)

- Pull Request

  - [x] PR のタイトルはわかりやすい名前が設定されていますか?(日本語でも可)
  - [x] PR の必須項目はすべて記載していますか?
  - [x] PR の必要ない項目は削除していますか?
  - [x] PR の内容と変更内容は一致していますか?
    - 1 機能=1PR であるべきです。1 機能の途中でも問題ありません

- Commit

  - [x] Commit メッセージはルール通りですか?
    - コミットメッセージの先頭に`[Add|Delete|Modify|Fix|Refactor|Move]`
      等の動詞の原形を追加してください。  
      ([参考](https://www.tam-tam.co.jp/tipsnote/program/post16686.html))  
      ([参考 2](https://note.com/haru_notes/n/n3d9c406e9ac6))
    - コミットメッセージの説明には`GH-〇〇`でチケット番号をつけてください  
      (チケットが存在しない場合は`NO-ISSUE`にしてください)
    - マージコミットの場合はこの限りではありません
    <!--
      例: GH-100 Add 特殊演出を追加
      例: NO-ISSUE Move フォルダを〇〇へ移動
      ブランチ名のようにfeatureやfixは必要ありません
    -->
  - [x] コミットの粒度は適切ですか?
    - 1 コミット=1 要素(1 ロジック)の変更であるべきです
    <!--
      例: ファイル移動してから内容変更したい場合は2回コミット分けるべきです
      例: デバッグメッセージ表示と新たなロジック追加した場合も2回コミット分けるべきです
    -->

- Branch
  - [x] ブランチの名前は正しいですか?
    - ブランチ名先頭は`feature/[簡単な説明]` または `fix/[簡単な説明]` であるべきです
    - 簡単な説明は英語であるべきです(不具合発生するので)
  - [x] ブランチの向き、切り先は正しいですか?

<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
