### PR TITLE
猛火斬の1.21.1移植

### DIFF
--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -98,7 +98,7 @@ scoreboard objectives add Burst dummy {"text":"バースト管理"}
 #剣士
 scoreboard objectives add FalconSlashTimer dummy {"text":"はやぶさ斬り遅延タイマー"}
 scoreboard objectives add IronWill dummy {"text":"アイアンウィル残りtick数"}
-scoreboard objectives add RagingDamage dummy {"text":"猛火斬ダメージ"}
+scoreboard objectives add RagingCount dummy {"text":"猛火斬カウント"}
 scoreboard objectives add OdinSlash dummy {"text":"斬鉄剣発動タイミング調整"}
 scoreboard objectives add ReactiveLevel dummy {"text":"リアクティブヒールレベル"}
 scoreboard objectives add TacticalHeal dummy {"text":"タクティカルヒール持続確率"}

--- a/data/main/function/task/temporary.mcfunction
+++ b/data/main/function/task/temporary.mcfunction
@@ -11,7 +11,7 @@ execute if score @s BlinkSubTimer matches 1.. run function skill:enemy/blink/act
 execute if score @s FalconSlashTimer matches 1.. run function skill:act/knight/falcon_slash/decorate/tick
 
 ###猛火斬ダメージ付与処理
-execute if score @s RagingDamage matches 1.. run function skill:act/knight/raging_slash/tick
+execute if score @s RagingCount matches 1.. run function skill:act/knight/raging_slash/tick
 
 ###詠唱演出
 execute if score @s NextActionTick matches 1.. run function skill:enemy/delay_action/act/

--- a/data/makeup/function/skill/act/knight/raging_slash/decorate.mcfunction
+++ b/data/makeup/function/skill/act/knight/raging_slash/decorate.mcfunction
@@ -1,0 +1,14 @@
+#>makeup:skill/act/knight/raging_slash/decorate
+## 猛火斬パーティクル
+
+particle minecraft:flame ^ ^ ^0.0 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^0.2 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^0.4 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^0.6 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^0.8 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^1.0 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^1.2 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^1.4 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^1.6 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^1.8 0 0 0 0 1 force
+particle minecraft:flame ^ ^ ^2.0 0 0 0 0 1 force

--- a/data/makeup/function/skill/act/knight/raging_slash/tick.mcfunction
+++ b/data/makeup/function/skill/act/knight/raging_slash/tick.mcfunction
@@ -1,0 +1,2 @@
+#>makeup:skill/act/knight/raging_slash/tick
+playsound minecraft:entity.zombie.attack_wooden_door player @a[distance=..16] ~ ~ ~ 0.8 0.7072

--- a/data/skill/function/act/knight/raging_slash/act0.mcfunction
+++ b/data/skill/function/act/knight/raging_slash/act0.mcfunction
@@ -2,4 +2,4 @@
 ## 猛火斬発動
 
 #ターゲットで実行
-execute at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:24000f}] run function skill:act/knight/raging_slash/act1
+execute at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:2048f}] run function skill:act/knight/raging_slash/act1

--- a/data/skill/function/act/knight/raging_slash/act0.mcfunction
+++ b/data/skill/function/act/knight/raging_slash/act0.mcfunction
@@ -1,0 +1,5 @@
+#>skill:act/knight/raging_slash/act0
+## 猛火斬発動
+
+#ターゲットで実行
+execute at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:24000f}] run function skill:act/knight/raging_slash/act1

--- a/data/skill/function/act/knight/raging_slash/act1.mcfunction
+++ b/data/skill/function/act/knight/raging_slash/act1.mcfunction
@@ -1,0 +1,23 @@
+#>skill:act/knight/raging_slash/act1
+## 猛火斬発動
+
+# 回数設定
+scoreboard players operation _ RagingCount = @s RagingCount
+scoreboard players set _ _ 1000
+scoreboard players operation _ RagingCount %= _ _
+execute store result score _ _ if entity @e[distance=..5,tag=Enemy]
+# 幻影
+execute as @e[distance=..5,tag=Enemy] run function skill:act/knight/raging_slash/get_blink
+scoreboard players operation _ RagingCount += _ _
+scoreboard players add _ RagingCount 3
+# 攻撃回数は1000以上にならない
+scoreboard players set _ _ 999
+scoreboard players operation _ RagingCount < _ _
+
+# スキルレベル*1000+回数 として保存
+scoreboard players operation @s RagingCount = _ Level
+scoreboard players set _ _ 1000
+scoreboard players operation @s RagingCount *= _ _
+scoreboard players operation @s RagingCount += _ RagingCount
+
+scoreboard players add @s NativeFlag 100

--- a/data/skill/function/act/knight/raging_slash/finalize.mcfunction
+++ b/data/skill/function/act/knight/raging_slash/finalize.mcfunction
@@ -1,0 +1,6 @@
+#>skill:act/knight/raging_slash/finalize
+## 猛火斬ダメージ終了
+
+# ダメージ中記録を解除する
+scoreboard players reset @s RagingCount
+scoreboard players remove @s NativeFlag 100

--- a/data/skill/function/act/knight/raging_slash/get_blink.mcfunction
+++ b/data/skill/function/act/knight/raging_slash/get_blink.mcfunction
@@ -1,0 +1,7 @@
+#>skill:act/knight/raging_slash/get_blink
+## 猛火斬幻影カウント
+
+scoreboard players set @s _ 0
+function #oh_my_dat:please
+execute store result score @s _ run data get storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Blink.Count
+scoreboard players operation _ _ += @s _

--- a/data/skill/function/act/knight/raging_slash/tick.mcfunction
+++ b/data/skill/function/act/knight/raging_slash/tick.mcfunction
@@ -13,17 +13,18 @@ scoreboard players operation _ Level = @s RagingCount
 scoreboard players set _ _ 1000
 scoreboard players operation _ Level /= _ _
 
+# 回数判定
+scoreboard players remove @s RagingCount 1
+scoreboard players operation _ RagingCount = @s RagingCount
+scoreboard players operation _ RagingCount %= _ _
+execute if score _ RagingCount matches ..0 run function skill:act/knight/raging_slash/finalize
+
 # ダメージを取得、適用
 execute if score _ Level matches 1 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"猛火斬",Level:1}].Damage
 execute if score _ Level matches 2 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"猛火斬",Level:2}].Damage
 execute if score _ Level matches 3 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"猛火斬",Level:3}].Damage
 function skill:damage/apply/
 
-# 回数判定
-scoreboard players remove @s RagingCount 1
-scoreboard players operation _ RagingCount = @s RagingCount
-scoreboard players operation _ RagingCount %= _ _
-execute if score _ RagingCount matches ..0 run function skill:act/knight/raging_slash/finalize
 
 tag @s add HitDamageTaken
 tag @s add ReceivedPhysicalDamage

--- a/data/skill/function/act/knight/raging_slash/tick.mcfunction
+++ b/data/skill/function/act/knight/raging_slash/tick.mcfunction
@@ -1,0 +1,29 @@
+#>skill:act/knight/raging_slash/tick
+## 猛火斬ダメージ付与
+
+function makeup:skill/act/knight/raging_slash/tick
+
+function calc:geometry/tp_00000
+execute as 0-0-0-0-0 at @s run function calc:set/random_rotation
+execute at @s positioned ~ ~1 ~ rotated as 0-0-0-0-0 facing ^ ^1 ^ positioned ^0.2 ^ ^-0.4 run function makeup:skill/act/knight/raging_slash/decorate
+execute as 0-0-0-0-0 run function calc:geometry/return_marker
+
+# スキルレベル取得
+scoreboard players operation _ Level = @s RagingCount
+scoreboard players set _ _ 1000
+scoreboard players operation _ Level /= _ _
+
+# ダメージを取得、適用
+execute if score _ Level matches 1 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"猛火斬",Level:1}].Damage
+execute if score _ Level matches 2 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"猛火斬",Level:2}].Damage
+execute if score _ Level matches 3 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"猛火斬",Level:3}].Damage
+function skill:damage/apply/
+
+# 回数判定
+scoreboard players remove @s RagingCount 1
+scoreboard players operation _ RagingCount = @s RagingCount
+scoreboard players operation _ RagingCount %= _ _
+execute if score _ RagingCount matches ..0 run function skill:act/knight/raging_slash/finalize
+
+tag @s add HitDamageTaken
+tag @s add ReceivedPhysicalDamage


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-670
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
猛火斬を1.21.1に移植した。

## やったこと
2tick以降のダメージ付与処理を@s damageの編集　から　_ Levelを保存、呼び出し→skill:damage/apply/　に変更
ohmydatを使用するより負荷が低いと考えてこの方式とした。

スコアRagingDamageをRagingCountに変更（ダメージを扱わなくなったため）

## レビュー観点
・斬撃が命中した相手に対して正常に発動するか。また、複数体命中時にバグが起こらないか。
・敵の数に応じて攻撃回数・ダメージが増加するか。
・Blink.Countに応じて攻撃回数・ダメージが増加するか。

デバッグ用コマンド
`scoreboard players operation _ RagingCount = @s RagingCount`
`tellraw @a [{"score":{"name":"_","objective":"RagingCount"}}]`

## 補足
・このプルリクエストは2回目のものです。猛火斬移行の過程は以下にも残っています。
https://github.com/TUSB/TheUnusualSkyBlock/pull/765

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
