### PR TITLE
敵デバフ：火だるまの追加

### DIFF
--- a/data/effect/function/enemy_debuff/burn/apply.mcfunction
+++ b/data/effect/function/enemy_debuff/burn/apply.mcfunction
@@ -1,0 +1,15 @@
+#> effect:enemy_debuff/burn/apply
+#
+# 敵火だるま付与
+
+#（火だるま耐性値）%の確率で失敗
+execute store result score _ _ run random value 1..100
+execute unless score @s BurnResistance < _ _ run return fail
+
+tag @s add EnemyBurn
+scoreboard players set @s BurnTimer 30
+
+# 凍結していたら解除する
+# execute if entity @s[tag=EnemyFreeze] run function effect:enemy_debuff/freeze/cure
+
+function makeup:effect/enemy_debuff/burn/apply

--- a/data/effect/function/enemy_debuff/burn/cure.mcfunction
+++ b/data/effect/function/enemy_debuff/burn/cure.mcfunction
@@ -1,0 +1,6 @@
+#> effect:enemy_debuff/burn/defuze
+#
+# 敵火だるま解除
+
+tag @s remove EnemyBurn
+scoreboard players reset @s BurnTimer

--- a/data/effect/function/enemy_debuff/burn/cure_check.mcfunction
+++ b/data/effect/function/enemy_debuff/burn/cure_check.mcfunction
@@ -1,0 +1,6 @@
+#> effect:enemy_debuff/burn/cure_check
+#
+# 敵火だるま解除判定
+
+execute store result score _ _ run random value 1..10
+execute if score _ _ matches 10 run function effect:enemy_debuff/burn/cure

--- a/data/effect/function/enemy_debuff/burn/damage.mcfunction
+++ b/data/effect/function/enemy_debuff/burn/damage.mcfunction
@@ -1,0 +1,7 @@
+#> effect:enemy_debuff/burn/hit
+#
+# 敵火だるまダメージ処理
+
+# ダメージ処理
+data modify storage entity: damage set value {physical:10}
+function entity:damage/apply/

--- a/data/effect/function/enemy_debuff/burn/second.mcfunction
+++ b/data/effect/function/enemy_debuff/burn/second.mcfunction
@@ -1,0 +1,12 @@
+#> effect:enemy_debuff/burn/second
+#
+# 敵火だるま毎秒処理
+
+# 残り時間をカウント、0以下なら解除
+scoreboard players remove @s BurnTimer 1
+execute if score @s BurnTimer matches ..0 run return run function effect:enemy_debuff/burn/cure
+
+# 自身と付近のEnemyに物理10ダメージ
+execute as @e[tag=Enemy,distance=..1] run function effect:enemy_debuff/burn/damage
+
+function makeup:effect/enemy_debuff/burn/second

--- a/data/effect/function/enemy_debuff/burn/tick.mcfunction
+++ b/data/effect/function/enemy_debuff/burn/tick.mcfunction
@@ -1,0 +1,6 @@
+#> effect:enemy_debuff/burn/tick
+#
+# 敵火だるま毎tick処理 
+
+# 水に触れていれば解除
+execute if predicate entity:in_all_water run function effect:enemy_debuff/burn/cure

--- a/data/enemy/function/damage/hit.mcfunction
+++ b/data/enemy/function/damage/hit.mcfunction
@@ -6,5 +6,8 @@ execute if entity @s[tag=CallOnDamage] at @s run function ai:call/trigger/damage
 #ダメージ表示
 function enemy:show_damage/
 
+#敵火だるま解除判定
+execute if entity @s[tag=EnemyBurn] run function effect:enemy_debuff/burn/cure_check
+
 #リセット
 tag @s remove HitDamageTaken

--- a/data/enemy/function/one_second.mcfunction
+++ b/data/enemy/function/one_second.mcfunction
@@ -2,3 +2,6 @@
 # -> 10秒処理
 ## 使用するときにコメントアウトを外してください。
 # execute if score $Seconds Count matches 0 run function enemy:ten_seconds
+
+### 敵火だるま1秒処理
+execute if entity @s[tag=EnemyBurn] run function effect:enemy_debuff/burn/second

--- a/data/enemy/function/tick.mcfunction
+++ b/data/enemy/function/tick.mcfunction
@@ -1,10 +1,12 @@
 #> enemy:tick
 # -> 1秒処理
-## 使用するときにコメントアウトを外してください。
-# execute if score $Ticks Count matches 0 run function enemy:one_second
+execute if score $Ticks Count matches 0 run function enemy:one_second
 
 ### Mob自然ダメージ反映
 execute if entity @s[nbt=!{AbsorptionAmount:2048f}] run function enemy:damage/natural
+
+### 敵火だるま
+execute if entity @s[tag=EnemyBurn] run function effect:enemy_debuff/burn/tick
 
 ### Mob Hitダメージ
 execute if entity @s[tag=HitDamageTaken] run function enemy:damage/hit

--- a/data/entity/predicate/in_all_water.json
+++ b/data/entity/predicate/in_all_water.json
@@ -1,0 +1,8 @@
+{
+  "condition": "location_check",
+  "predicate": {
+    "fluid": {
+      "fluids": "#minecraft:water"
+    }
+  }
+}

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -59,6 +59,8 @@ scoreboard objectives add PalsyLevel dummy {"text":"麻痺レベル"}
 scoreboard objectives add TntCount dummy {"text":"トントカウント"}
 scoreboard objectives add VirusCount dummy {"text":"病気カウント"}
 scoreboard objectives add FreezeTimer dummy {"text":"凍結タイマー"}
+scoreboard objectives add BurnResistance dummy {"text":"火だるま耐性"}
+scoreboard objectives add BurnTimer dummy {"text":"火だるまタイマー"}
 scoreboard objectives add BurnCount dummy {"text":"火だるまカウント"}
 scoreboard objectives add GameTime dummy {"text":"ゲームタイム"}
 scoreboard objectives add ProjectileTime minecraft.custom:minecraft.play_time {"text":"投射物ヒットタイマー"}

--- a/data/makeup/function/effect/enemy_debuff/burn/apply.mcfunction
+++ b/data/makeup/function/effect/enemy_debuff/burn/apply.mcfunction
@@ -1,0 +1,6 @@
+#> makeup:effect/enemy_debuff/burn/apply
+#
+# 敵火だるま付与演出
+
+particle flame ~ ~0.5 ~ 0.2 0.2 0.2 0.2 20
+playsound item.firecharge.use hostile @a ~ ~ ~ 1 0.8

--- a/data/makeup/function/effect/enemy_debuff/burn/second.mcfunction
+++ b/data/makeup/function/effect/enemy_debuff/burn/second.mcfunction
@@ -1,0 +1,7 @@
+#> makeup:effect/enemy_debuff/burn/second
+#
+# 敵火だるま毎秒演出
+
+particle minecraft:dust{color:[100000000,2,0],scale:2} ~ ~1 ~ 0.5 0.5 0.5 1 15 force
+particle flame ~ ~0.5 ~ 0.2 0.2 0.2 0.1 10
+playsound minecraft:entity.player.hurt_on_fire hostile @a ~ ~ ~ 1 1

--- a/data/player/function/trigger/hurt_entity/.mcfunction
+++ b/data/player/function/trigger/hurt_entity/.mcfunction
@@ -11,7 +11,7 @@ execute if entity @s[advancements={player:trigger/hurt_entity={melee_bow_attack=
 execute if entity @s[advancements={player:trigger/hurt_entity={sword_attack_sweep=true}}] run function player:trigger/hurt_entity/sword_attack_sweep
 
 ##AbsorptionAmountリセット
-execute at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:2048f},distance=0] run function enemy:damage/update_health
+execute at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:2048f},distance=0] run function enemy:damage/natural
 
 #トリガーリセット
 advancement revoke @s only player:trigger/hurt_entity


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-795
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
敵デバフのうち火だるまを追加した。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
スコアボードを追加
`BurnTimer`（敵火だるまタイマー）,`BurnResistance`（敵火だるま耐性）

タグを追加
`EnemyBurn`（敵火だるま検知用）

水接触用のプレディケートを追加
## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
未実装のため競合による凍結の解除はコメントアウト
## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
`effect:enemy_debuff/burn/apply`を対象のエンティティで実行する。
`BurnResistance`を0に設定すれば100％、100に設定すれば0％の確率で付与される。
`effect:enemy_debuff/burn/cure`を実行で解除
`HitDamageTaken`付与時に_ _が1~10で抽選、10であれば解除
## レビュー観点<!-- なかったらこの項目を削除してください -->
<!-- - 想定通りに動作するか？ -->
<!-- - 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ -->
・ファイルの命名と場所に問題がないか
・演出が正常かつ負荷にならない程度に動作しているか
## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->
解除はプレイヤーデバフと共通化のためdefuse→cureにしました
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
