### PR TITLE
影封縫の1.21.4移植

### DIFF
--- a/data/makeup/function/skill/act/knight/shadow_thrust/act1.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/act1.mcfunction
@@ -1,0 +1,1 @@
+particle sweep_attack ~ ~0.15 ~ 0 0 0 4 5 force

--- a/data/makeup/function/skill/act/knight/shadow_thrust/act1.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/act1.mcfunction
@@ -1,1 +1,2 @@
+#> makeup:skill/act/knight/shadow_thrust/act1
 particle sweep_attack ~ ~0.15 ~ 0 0 0 4 5 force

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick.mcfunction
@@ -1,0 +1,2 @@
+particle squid_ink ~ ~ ~ 1.2 0 1.2 0.05 5 force
+particle minecraft:reverse_portal ~ ~ ~ 1 0 1 0.05 10 force

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick.mcfunction
@@ -1,2 +1,3 @@
+#> makeup:skill/act/knight/shadow_thrust/tick
 particle squid_ink ~ ~ ~ 1.2 0 1.2 0.05 5 force
 particle minecraft:reverse_portal ~ ~ ~ 1 0 1 0.05 10 force

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick.mcfunction
@@ -1,3 +1,3 @@
 #> makeup:skill/act/knight/shadow_thrust/tick
-particle squid_ink ~ ~ ~ 1.2 0 1.2 0.05 5 force
-particle minecraft:reverse_portal ~ ~ ~ 1 0 1 0.05 10 force
+particle squid_ink ~ ~ ~ 1.2 0 1.2 0.05 5 force @a[tag=ShowParticles]
+particle minecraft:reverse_portal ~ ~ ~ 1 0 1 0.05 10 force @a[tag=ShowParticles]

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -1,4 +1,4 @@
 particle item{item:chain} ~ ~2 ~ 0.2 1.5 0.2 0.01 50 force
-particle minecraft:dust_color_transition{from_color:6230894,scale:1,to_color:4919134} ~ ~2 ~ 0 1.5 0 0 20 force
+particle minecraft:dust_color_transition{from_color:13107866,scale:1,to_color:261} ~ ~2 ~ 0 1.5 0 0 20 force
 playsound minecraft:block.chain.break player @a ~ ~ ~ 1 0
 playsound minecraft:entity.hoglin.attack player @a ~ ~ ~ 0.5 0

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -1,3 +1,4 @@
+#> makeup:skill/act/knight/shadow_thrust/tick_mob
 particle item{item:chain} ~ ~2 ~ 0.2 1.5 0.2 0.01 50 force
 particle minecraft:dust_color_transition{from_color:13107866,scale:1,to_color:261} ~ ~2 ~ 0 1.5 0 0 20 force
 playsound minecraft:block.chain.break player @a ~ ~ ~ 1 0

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -1,0 +1,4 @@
+particle item{item:chain} ~ ~2 ~ 0.2 1.5 0.2 0.01 50 force
+particle minecraft:dust_color_transition{from_color:6230894,scale:1,to_color:4919134} ~ ~2 ~ 0 1.5 0 0 20 force
+playsound minecraft:block.chain.break master @a ~ ~ ~ 1 0
+playsound minecraft:entity.hoglin.attack master @a ~ ~ ~ 0.5 0

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -1,5 +1,5 @@
 #> makeup:skill/act/knight/shadow_thrust/tick_mob
-particle item{item:chain} ~ ~2 ~ 0.2 1.5 0.2 0.01 50 force
-particle minecraft:dust_color_transition{from_color:13107866,scale:1,to_color:261} ~ ~2 ~ 0 1.5 0 0 20 force
+particle item{item:chain} ~ ~2 ~ 0.2 1.5 0.2 0.01 50 force @a[tag=ShowParticles]
+particle minecraft:dust_color_transition{from_color:13107866,scale:1,to_color:261} ~ ~2 ~ 0 1.5 0 0 20 force @a[tag=ShowParticles]
 playsound minecraft:block.chain.break player @a ~ ~ ~ 1 0
 playsound minecraft:entity.hoglin.attack player @a ~ ~ ~ 0.5 0

--- a/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/makeup/function/skill/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -1,4 +1,4 @@
 particle item{item:chain} ~ ~2 ~ 0.2 1.5 0.2 0.01 50 force
 particle minecraft:dust_color_transition{from_color:6230894,scale:1,to_color:4919134} ~ ~2 ~ 0 1.5 0 0 20 force
-playsound minecraft:block.chain.break master @a ~ ~ ~ 1 0
-playsound minecraft:entity.hoglin.attack master @a ~ ~ ~ 0.5 0
+playsound minecraft:block.chain.break player @a ~ ~ ~ 1 0
+playsound minecraft:entity.hoglin.attack player @a ~ ~ ~ 0.5 0

--- a/data/skill/function/act/knight/shadow_thrust/act0.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/act0.mcfunction
@@ -1,0 +1,5 @@
+
+## 影封縫発動
+
+#ターゲットで実行
+execute at 0-0-0-0-2 run function skill:act/knight/shadow_thrust/act1

--- a/data/skill/function/act/knight/shadow_thrust/act0.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/act0.mcfunction
@@ -1,5 +1,6 @@
-
-## 影封縫発動
+#> skill:act/knight/shadow_thrust/act0
+#
+# 影封縫発動
 
 #ターゲットで実行
 execute at 0-0-0-0-2 run function skill:act/knight/shadow_thrust/act1

--- a/data/skill/function/act/knight/shadow_thrust/act1.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/act1.mcfunction
@@ -1,0 +1,13 @@
+
+## 影封縫発動
+
+# ダメージ計算
+execute if score _ Level matches 1 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"影封縫",Level:1}].Damage
+execute if score _ Level matches 2 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"影封縫",Level:2}].Damage
+execute if score _ Level matches 3 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"影封縫",Level:3}].Damage
+function skill:damage/add/skill/weapon
+#ダメージを保存
+summon armor_stand ~ ~0.5 ~ {Tags:[Skill,ShadowThrust,NativeTask,CooldownRequired],PortalCooldown:40,Invisible:1b,Silent:1b,Small:1b,Invulnerable:1b}
+execute positioned ~ ~0.5 ~ as @e[tag=ShadowThrust,tag=!Initialized,distance=..0.01] run function skill:damage/save
+#演出
+function makeup:skill/act/knight/shadow_thrust/act1

--- a/data/skill/function/act/knight/shadow_thrust/act1.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/act1.mcfunction
@@ -1,5 +1,6 @@
-
-## 影封縫発動
+#> skill:act/knight/shadow_thrust/act1
+#
+# 影封縫発動
 
 # ダメージ計算
 execute if score _ Level matches 1 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"影封縫",Level:1}].Damage

--- a/data/skill/function/act/knight/shadow_thrust/act1.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/act1.mcfunction
@@ -6,9 +6,10 @@
 execute if score _ Level matches 1 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"影封縫",Level:1}].Damage
 execute if score _ Level matches 2 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"影封縫",Level:2}].Damage
 execute if score _ Level matches 3 run data modify storage skill: damage set from storage skill: Data.Knight[{Name:"影封縫",Level:3}].Damage
-function skill:damage/add/skill/weapon
 #ダメージを保存
-summon armor_stand ~ ~0.5 ~ {Tags:[Skill,ShadowThrust,NativeTask,CooldownRequired],PortalCooldown:40,Invisible:1b,Silent:1b,Small:1b,Invulnerable:1b}
+summon armor_stand ~ ~0.5 ~ {Tags:[Skill,ShadowThrust,CooldownRequired],PortalCooldown:40,Invisible:1b,Silent:1b,Small:1b,Invulnerable:1b}
 execute positioned ~ ~0.5 ~ as @e[tag=ShadowThrust,tag=!Initialized,distance=..0.01] run function skill:damage/save
+#NativeFlagをインクリメント
+execute positioned ~ ~0.5 ~ run scoreboard players add @e[tag=ShadowThrust,tag=!Initialized,distance=..0.01] NativeFlag 1
 #演出
 function makeup:skill/act/knight/shadow_thrust/act1

--- a/data/skill/function/act/knight/shadow_thrust/tick.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/tick.mcfunction
@@ -1,0 +1,9 @@
+
+## 影封縫tick
+
+#ダメージをロード
+function skill:damage/load
+#ポイントから離れたモブにダメージ
+execute as @e[tag=Enemy,distance=..4] at @s unless entity @e[tag=ShadowThrustPoint,distance=..0.5] run function skill:act/knight/shadow_thrust/tick_mob
+#演出
+function makeup:skill/act/knight/shadow_thrust/tick

--- a/data/skill/function/act/knight/shadow_thrust/tick.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/tick.mcfunction
@@ -1,5 +1,6 @@
-
-## 影封縫tick
+#> skill:act/knight/shadow_thrust/tick
+#
+# 影封縫tick
 
 #ダメージをロード
 function skill:damage/load

--- a/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -1,0 +1,13 @@
+
+## 影封縫tick Mob
+
+#ノックバック+下に落とす
+execute rotated ~ 0 run tp @s[tag=!Unmoved] ^ ^ ^-0.4
+execute store result score _ _ run data get entity @s[tag=!Unmoved] Motion[1] 100
+execute store result entity @s[tag=!Unmoved] Motion[1] double 0.01 run scoreboard players remove _ _ 50
+#ポイント設置
+summon area_effect_cloud ~ ~ ~ {Tags:[Skill,ShadowThrustPoint],Duration:25}
+#ダメージ付与
+function skill:damage/apply/
+#演出
+function makeup:skill/act/knight/shadow_thrust/tick_mob

--- a/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -1,5 +1,6 @@
-
-## 影封縫tick Mob
+#> skill:act/knight/shadow_thrust/tick_mob
+#
+# 影封縫tick Mob
 
 #ノックバック+下に落とす
 execute rotated ~ 0 run tp @s[tag=!Unmoved] ^ ^ ^-0.4

--- a/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -11,6 +11,6 @@ summon area_effect_cloud ~ ~ ~ {Tags:[Skill,ShadowThrustPoint],Duration:25}
 #ダメージ付与
 function skill:damage/apply/
 #デバフ付与
-function effect:enemy_debuff/fear/apply
+function effect:enemy_debuff/curse/apply
 #演出
 function makeup:skill/act/knight/shadow_thrust/tick_mob

--- a/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
+++ b/data/skill/function/act/knight/shadow_thrust/tick_mob.mcfunction
@@ -9,5 +9,7 @@ execute store result entity @s[tag=!Unmoved] Motion[1] double 0.01 run scoreboar
 summon area_effect_cloud ~ ~ ~ {Tags:[Skill,ShadowThrustPoint],Duration:25}
 #ダメージ付与
 function skill:damage/apply/
+#デバフ付与
+function effect:enemy_debuff/fear/apply
 #演出
 function makeup:skill/act/knight/shadow_thrust/tick_mob

--- a/data/skill/function/native_tick.mcfunction
+++ b/data/skill/function/native_tick.mcfunction
@@ -7,7 +7,7 @@
 # 真空斬り
 execute if entity @s[tag=AerialSlash] run function skill:act/knight/aerial_slash/tick
 
-###影封縫
+# 影封縫
 execute if entity @s[tag=ShadowThrust] run function skill:act/knight/shadow_thrust/tick
 
 ## 忍者

--- a/data/skill/function/native_tick.mcfunction
+++ b/data/skill/function/native_tick.mcfunction
@@ -7,6 +7,9 @@
 # 真空斬り
 execute if entity @s[tag=AerialSlash] run function skill:act/knight/aerial_slash/tick
 
+###影封縫
+execute if entity @s[tag=ShadowThrust] run function skill:act/knight/shadow_thrust/tick
+
 ## 忍者
 # 介錯
 execute if entity @s[tag=KaishakuExplosion] run function skill:act/ninja/kaishaku/explode_tick


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
GH-860

## 対応内容・対応背景・妥協点
影封縫を1.21.4に移植した。

## やったこと
ファイルの移動
エネミーデバフ付与
ダストカラーの10進数化
master=>player

## テスト
シングルプレイにて全てのレベルで動作を確認しました。
マルチでのテストは行っていません。

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
