### PR TITLE
連舞の1.21.4移植

### DIFF
--- a/data/makeup/function/skill/act/ninja/tsuremai/attack.mcfunction
+++ b/data/makeup/function/skill/act/ninja/tsuremai/attack.mcfunction
@@ -8,10 +8,10 @@ data modify storage calc: TextLength set value 4
 title @s times 0 80 20
 function calc:show_text/subtitle
 
-playsound minecraft:entity.zombie.attack_iron_door master @a[distance=..16] ~ ~ ~ 2 2
-execute if score _ _ matches ..8 run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 0.4
-execute if score _ _ matches 9..16 run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 0.8
-execute if score _ _ matches 17..24 run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 1.2
-execute if score _ _ matches 25.. run playsound minecraft:item.trident.riptide_1 master @a[distance=..16] ~ ~ ~ 1 1.2
+playsound minecraft:entity.zombie.attack_iron_door player @a[distance=..16] ~ ~ ~ 2 2
+execute if score _ _ matches ..8 run playsound minecraft:entity.witch.throw player @a[distance=..16] ~ ~ ~ 1 0.4
+execute if score _ _ matches 9..16 run playsound minecraft:entity.witch.throw player @a[distance=..16] ~ ~ ~ 1 0.8
+execute if score _ _ matches 17..24 run playsound minecraft:entity.witch.throw player @a[distance=..16] ~ ~ ~ 1 1.2
+execute if score _ _ matches 25.. run playsound minecraft:item.trident.riptide_1 player @a[distance=..16] ~ ~ ~ 1 1.2
 particle minecraft:sweep_attack ^ ^0.2 ^1.3 0 0 0 2.5 2 force
 execute as @e[tag=MeleeTarget,limit=1] at @s run particle minecraft:sweep_attack ~ ~0.5 ~ 0 0.5 0 1 5 force

--- a/data/makeup/function/skill/act/ninja/tsuremai/attack.mcfunction
+++ b/data/makeup/function/skill/act/ninja/tsuremai/attack.mcfunction
@@ -1,0 +1,17 @@
+#> makeup:skill/act/ninja/tsuremai/attack
+#
+# 連舞attack演出
+
+execute if score @s _ matches ..24 run data modify storage calc: Text set value '[{"translate":"%1$s Hit!!","color":"yellow","bold":true,"with":[{"score":{"name":"@s","objective":"_"}}]}]'
+execute if score @s _ matches 25.. run data modify storage calc: Text set value '[{"translate":"%1$s Hit!!","color":"gold","bold":true,"with":[{"score":{"name":"@s","objective":"_"}}]}]'
+data modify storage calc: TextLength set value 4
+title @s times 0 80 20
+function calc:show_text/subtitle
+
+playsound minecraft:entity.zombie.attack_iron_door master @a[distance=..16] ~ ~ ~ 2 2
+execute if score _ _ matches ..8 run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 0.4
+execute if score _ _ matches 9..16 run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 0.8
+execute if score _ _ matches 17..24 run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 1.2
+execute if score _ _ matches 25.. run playsound minecraft:item.trident.riptide_1 master @a[distance=..16] ~ ~ ~ 1 1.2
+particle minecraft:sweep_attack ^ ^0.2 ^1.3 0 0 0 2.5 2 force
+execute as @e[tag=MeleeTarget,limit=1] at @s run particle minecraft:sweep_attack ~ ~0.5 ~ 0 0.5 0 1 5 force

--- a/data/makeup/function/skill/act/ninja/tsuremai/toggle.mcfunction
+++ b/data/makeup/function/skill/act/ninja/tsuremai/toggle.mcfunction
@@ -1,0 +1,10 @@
+#> makeup:skill/act/ninja/tsuremai/toggle
+#
+# 連舞切り替え演出
+
+execute if entity @s[scores={TsuremaiLevel=1..}] run tellraw @s [{"translate":"%1$sに%2$sの効果！","color":"green","with":[{"selector":"@s"},{"translate":"連舞","color":"white","hoverEvent":{"action":"show_text","value":[{"translate":"近接攻撃するほど攻撃力が上がる。"}]}}]}]
+execute unless entity @s[scores={TsuremaiLevel=1..}] run tellraw @s [{"translate":"%1$sの%2$sの効果が切れた。","color":"yellow","with":[{"selector":"@s","color":"white"},{"translate":"連舞","color":"white","hoverEvent":{"action":"show_text","value":{"translate":"近接攻撃するほど攻撃力が上がる。"}}}]}]
+
+execute if entity @s[scores={TsuremaiLevel=1..}] run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 0.4
+execute if entity @s[scores={TsuremaiLevel=1..}] rotated ~ 0 run particle minecraft:sweep_attack ^ ^0.2 ^1.3 0 0 0 2.5 2 force
+execute unless entity @s[scores={TsuremaiLevel=1..}] run playsound minecraft:block.lever.click master @s ~ ~ ~ 1 1

--- a/data/makeup/function/skill/act/ninja/tsuremai/toggle.mcfunction
+++ b/data/makeup/function/skill/act/ninja/tsuremai/toggle.mcfunction
@@ -5,6 +5,6 @@
 execute if entity @s[scores={TsuremaiLevel=1..}] run tellraw @s [{"translate":"%1$sに%2$sの効果！","color":"green","with":[{"selector":"@s"},{"translate":"連舞","color":"white","hoverEvent":{"action":"show_text","value":[{"translate":"近接攻撃するほど攻撃力が上がる。"}]}}]}]
 execute unless entity @s[scores={TsuremaiLevel=1..}] run tellraw @s [{"translate":"%1$sの%2$sの効果が切れた。","color":"yellow","with":[{"selector":"@s","color":"white"},{"translate":"連舞","color":"white","hoverEvent":{"action":"show_text","value":{"translate":"近接攻撃するほど攻撃力が上がる。"}}}]}]
 
-execute if entity @s[scores={TsuremaiLevel=1..}] run playsound minecraft:entity.witch.throw master @a[distance=..16] ~ ~ ~ 1 0.4
+execute if entity @s[scores={TsuremaiLevel=1..}] run playsound minecraft:entity.witch.throw player @a[distance=..16] ~ ~ ~ 1 0.4
 execute if entity @s[scores={TsuremaiLevel=1..}] rotated ~ 0 run particle minecraft:sweep_attack ^ ^0.2 ^1.3 0 0 0 2.5 2 force
-execute unless entity @s[scores={TsuremaiLevel=1..}] run playsound minecraft:block.lever.click master @s ~ ~ ~ 1 1
+execute unless entity @s[scores={TsuremaiLevel=1..}] run playsound minecraft:block.lever.click player @s ~ ~ ~ 1 1

--- a/data/player/function/trigger/hurt_entity/melee_attack.mcfunction
+++ b/data/player/function/trigger/hurt_entity/melee_attack.mcfunction
@@ -15,7 +15,7 @@ data remove storage item: Item
 data modify storage item: Item set from storage item: Items[{components:{"minecraft:custom_data":{Skill:{Trigger:"近接攻撃する"}}}}]
 
 ### 忍者＜連舞＞
-# execute if score @s TsuremaiLevel matches 1.. run function skill:act/ninja/tsuremai/trigger/attack
+execute if score @s TsuremaiLevel matches 1.. run function skill:act/ninja/tsuremai/trigger/attack
 
 #近接スキルの場合、物理ダメージはスキル側で計算するため0にする
 execute if data storage item: Item.components."minecraft:custom_data".Skill.Damage{melee:1b} at 0-0-0-0-2 run data modify entity @e[tag=Enemy,nbt=!{AbsorptionAmount:2048f},distance=0,limit=1] AbsorptionAmount set value 2048f

--- a/data/skill/function/act/ninja/tsuremai/act0.mcfunction
+++ b/data/skill/function/act/ninja/tsuremai/act0.mcfunction
@@ -1,0 +1,6 @@
+#> skill:act/ninja/tsuremai/act0
+#
+# 連舞 分岐
+
+execute if data storage skill: Skill{Trigger:"手に持って右クリック"} run function skill:act/ninja/tsuremai/toggle
+execute if data storage skill: Skill{Trigger:"近接攻撃する"} run function skill:act/ninja/tsuremai/attack

--- a/data/skill/function/act/ninja/tsuremai/attack.mcfunction
+++ b/data/skill/function/act/ninja/tsuremai/attack.mcfunction
@@ -1,0 +1,31 @@
+#> skill:act/ninja/tsuremai/attack
+#
+# 連舞発動
+
+#minecraft:effect.strengthの1/3を取得
+execute store result score @s _ run attribute @s minecraft:attack_damage modifier value get minecraft:effect.strength 0.334
+
+# 攻撃力上昇付与マクロ effectlevelは23まで
+execute if score @s _ matches 24.. run scoreboard players set @s _ 24
+execute store result storage skill: macro int 1 run scoreboard players get @s _
+execute if data storage skill: {macro:24} run data modify storage skill: macro set value 23
+effect clear @s minecraft:strength
+function skill:act/ninja/tsuremai/effect_macro with storage skill:
+data remove storage skill: macro
+
+scoreboard players add @s _ 1
+
+#演出
+function makeup:skill/act/ninja/tsuremai/attack
+
+#スキルレベルによるダメージ追加
+execute if score _ Level matches 1 run data modify storage skill: damage set from storage skill: Data.Ninja[{Name:"連舞",Level:1}].Damage
+execute if score _ Level matches 2 run data modify storage skill: damage set from storage skill: Data.Ninja[{Name:"連舞",Level:2}].Damage
+execute if score _ Level matches 3 run data modify storage skill: damage set from storage skill: Data.Ninja[{Name:"連舞",Level:3}].Damage
+execute if score _ Level matches 4 run data modify storage skill: damage set from storage skill: Data.Ninja[{Name:"連舞",Level:4}].Damage
+
+#ダメージ付与
+#同時に近接スキル発動の場合そちらでダメージ付与するためここでは行わない
+#付与後は近接スキルフラグを付与してダメージ重複を防ぐ
+execute unless data storage item: Item.tag.Skill.Damage{melee:1b} at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:1000000f},distance=0] run function skill:damage/apply/
+execute unless data storage item: Item.tag.Skill.Damage{melee:1b} run data modify storage item: Item.tag.Skill.Damage.melee set value 1b

--- a/data/skill/function/act/ninja/tsuremai/attack.mcfunction
+++ b/data/skill/function/act/ninja/tsuremai/attack.mcfunction
@@ -8,7 +8,6 @@ execute store result score @s _ run attribute @s minecraft:attack_damage modifie
 # 攻撃力上昇付与マクロ effectlevelは23まで
 execute if score @s _ matches 24.. run scoreboard players set @s _ 24
 execute store result storage skill: macro int 1 run scoreboard players get @s _
-execute if data storage skill: {macro:24} run data modify storage skill: macro set value 23
 effect clear @s minecraft:strength
 function skill:act/ninja/tsuremai/effect_macro with storage skill:
 data remove storage skill: macro

--- a/data/skill/function/act/ninja/tsuremai/attack.mcfunction
+++ b/data/skill/function/act/ninja/tsuremai/attack.mcfunction
@@ -23,9 +23,3 @@ execute if score _ Level matches 1 run data modify storage skill: damage set fro
 execute if score _ Level matches 2 run data modify storage skill: damage set from storage skill: Data.Ninja[{Name:"連舞",Level:2}].Damage
 execute if score _ Level matches 3 run data modify storage skill: damage set from storage skill: Data.Ninja[{Name:"連舞",Level:3}].Damage
 execute if score _ Level matches 4 run data modify storage skill: damage set from storage skill: Data.Ninja[{Name:"連舞",Level:4}].Damage
-
-#ダメージ付与
-#同時に近接スキル発動の場合そちらでダメージ付与するためここでは行わない
-#付与後は近接スキルフラグを付与してダメージ重複を防ぐ
-execute unless data storage item: Item.tag.Skill.Damage{melee:1b} at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:1000000f},distance=0] run function skill:damage/apply/
-execute unless data storage item: Item.tag.Skill.Damage{melee:1b} run data modify storage item: Item.tag.Skill.Damage.melee set value 1b

--- a/data/skill/function/act/ninja/tsuremai/effect_macro.mcfunction
+++ b/data/skill/function/act/ninja/tsuremai/effect_macro.mcfunction
@@ -1,0 +1,5 @@
+#> skill:act/ninja/tsuremai/effect_macro
+#
+# 連舞エフェクト付与マクロ
+
+$effect give @s minecraft:strength 5 $(macro)

--- a/data/skill/function/act/ninja/tsuremai/toggle.mcfunction
+++ b/data/skill/function/act/ninja/tsuremai/toggle.mcfunction
@@ -1,0 +1,10 @@
+#> skill:act/ninja/tsuremai/toggle
+#
+# 連舞 人参棒でトグル
+
+scoreboard players set _ _ 0
+execute if entity @a[distance=..32,scores={Burst=0..,Job=7}] run scoreboard players remove _ Level 1
+execute if score @s TsuremaiLevel = _ Level store success score _ _ run scoreboard players reset @s TsuremaiLevel
+execute unless score @s TsuremaiLevel = _ Level if score _ _ matches 0 run scoreboard players operation @s TsuremaiLevel = _ Level
+#演出
+function makeup:skill/act/ninja/tsuremai/toggle

--- a/data/skill/function/act/ninja/tsuremai/trigger/attack.mcfunction
+++ b/data/skill/function/act/ninja/tsuremai/trigger/attack.mcfunction
@@ -1,0 +1,13 @@
+#> skill:act/ninja/tsuremai/trigger/attack
+#
+# 連舞 近接攻撃時
+
+scoreboard players operation _ Level = @s TsuremaiLevel
+
+execute if score _ Level matches 1 run data modify storage skill: Skill set from storage skill: Data.Ninja[{Name:"連舞",Level:1}]
+execute if score _ Level matches 2 run data modify storage skill: Skill set from storage skill: Data.Ninja[{Name:"連舞",Level:2}]
+execute if score _ Level matches 3 run data modify storage skill: Skill set from storage skill: Data.Ninja[{Name:"連舞",Level:3}]
+execute if score _ Level matches 4 run data modify storage skill: Skill set from storage skill: Data.Ninja[{Name:"連舞",Level:4}]
+data modify storage skill: Skill.Trigger set value "近接攻撃する"
+data modify storage skill: Skill.Type set value "Trigger"
+execute unless score @s FreezeTimer matches 0.. unless data entity @s SelectedItem.components."minecraft:custom_data".skill{Name:"ラピッドコンボ"} run function skill:practice/check_type


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
GH-868
<!-- チケット番号がない場合は NO-ISSUE -->

## 対応内容・対応背景・妥協点<!-- 必須 -->
連舞を1.21.4に移植した。

## やったこと<!-- 必須 -->
・攻撃力上昇付与をmacro化
・macro化によるファイル追加
・連舞内のダメージ重複処理を削除
・ファイルの移植

## やってないこと
マルチでの検証

## テスト
ソロにてv13α2のように攻撃力上昇effectが24Lvまでで止まり、連舞Lvは25まで上がるように動作した。

## レビュー観点
想定通りに動作するか？
削除した部分に問題はないか？

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
