### PR TITLE
黙想の1.21.4移植

### DIFF
--- a/data/makeup/function/skill/act/ninja/mokuso/act0.mcfunction
+++ b/data/makeup/function/skill/act/ninja/mokuso/act0.mcfunction
@@ -1,0 +1,3 @@
+playsound minecraft:block.conduit.ambient player @a[distance=..16] ~ ~ ~ 1 1
+playsound minecraft:block.conduit.attack.target player @a[distance=..16] ~ ~ ~ 1 0
+particle minecraft:nautilus ~ ~2 ~ 1.5 1 1.5 1 50 force

--- a/data/makeup/function/skill/act/ninja/mokuso/act0.mcfunction
+++ b/data/makeup/function/skill/act/ninja/mokuso/act0.mcfunction
@@ -1,3 +1,7 @@
+#> makeup:skill/act/ninja/mokuso/act0
+#
+# 黙想発動時演出
+
 playsound minecraft:block.conduit.ambient player @a[distance=..16] ~ ~ ~ 1 1
 playsound minecraft:block.conduit.attack.target player @a[distance=..16] ~ ~ ~ 1 0
 particle minecraft:nautilus ~ ~2 ~ 1.5 1 1.5 1 50 force

--- a/data/makeup/function/skill/act/ninja/mokuso/tick.mcfunction
+++ b/data/makeup/function/skill/act/ninja/mokuso/tick.mcfunction
@@ -1,3 +1,7 @@
+#> makeup:skill/act/ninja/mokuso/tick
+#
+# 黙想発動中演出
+
 playsound minecraft:ambient.underwater.loop.additions player @s ~ ~ ~ 1 1
 particle minecraft:nautilus ~ ~2 ~ 1.5 1 1.5 1 2 force @a[tag=ShowParticles]
 execute if score _ _ matches 0 run playsound minecraft:ambient.underwater.exit player @s ~ ~ ~ 1 1.6

--- a/data/makeup/function/skill/act/ninja/mokuso/tick.mcfunction
+++ b/data/makeup/function/skill/act/ninja/mokuso/tick.mcfunction
@@ -1,0 +1,4 @@
+playsound minecraft:ambient.underwater.loop.additions player @s ~ ~ ~ 1 1
+particle minecraft:nautilus ~ ~2 ~ 1.5 1 1.5 1 2 force @a[tag=ShowParticles]
+execute if score _ _ matches 0 run playsound minecraft:ambient.underwater.exit player @s ~ ~ ~ 1 1.6
+execute if score _ _ matches 0 run playsound minecraft:block.glass.break player @s ~ ~ ~ 1 0

--- a/data/skill/function/act/ninja/mokuso/act0.mcfunction
+++ b/data/skill/function/act/ninja/mokuso/act0.mcfunction
@@ -1,0 +1,9 @@
+#> skill:act/ninja/mokuso/act0
+#
+# 黙想発動
+
+effect give @s minecraft:regeneration 1 3
+summon minecraft:armor_stand ~ ~ ~ {Tags:[Skill,MokusoPoint,CooldownRequired],PortalCooldown:21,Marker:1b,NoGravity:1b,Invisible:1b,Invulnerable:1b}
+scoreboard players operation @s Mokuso = _ Level
+#演出
+function makeup:skill/act/ninja/mokuso/act0

--- a/data/skill/function/act/ninja/mokuso/tick.mcfunction
+++ b/data/skill/function/act/ninja/mokuso/tick.mcfunction
@@ -1,0 +1,15 @@
+#> skill:act/ninja/mokuso/tick
+#
+# 黙想継続
+
+scoreboard players set _ _ 0
+execute if score @s Mokuso matches 1 store success score _ _ run data modify entity @e[distance=..1,tag=MokusoPoint,limit=1,sort=nearest] PortalCooldown set value 21
+execute if score @s Mokuso matches 2 store success score _ _ run data modify entity @e[distance=..4,tag=MokusoPoint,limit=1,sort=nearest] PortalCooldown set value 21
+execute if score @s Mokuso matches 3 store success score _ _ run data modify entity @e[distance=..10,tag=MokusoPoint,limit=1,sort=nearest] PortalCooldown set value 21
+
+execute if score _ _ matches 0 run scoreboard players reset @s Mokuso
+execute if score _ _ matches 0 run tellraw @s [{"translate":"%1$sの%2$sの効果が切れた。","color":"yellow","with":[{"selector":"@s","color":"white"},{"translate":"黙想","color":"white","hoverEvent":{"action":"show_text","value":[{"translate":"自身の体力を徐々に回復する。"},"\n",{"translate":"ある程度移動すると効果が切れる。"}],"color":"white"}}]}]
+
+execute if score _ _ matches 1 run effect give @s minecraft:regeneration 1 3
+#演出
+function makeup:skill/act/ninja/mokuso/tick

--- a/data/skill/function/player_one_second.mcfunction
+++ b/data/skill/function/player_one_second.mcfunction
@@ -6,3 +6,6 @@
 ## 忍者
 # 風切
 execute if entity @s[scores={Kazakiri=0..}] run function skill:act/ninja/kazakiri/second
+
+# 黙想
+execute if entity @s[scores={Mokuso=0..}] run function skill:act/ninja/mokuso/tick


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL
GH-872

## 対応内容・対応背景・妥協点
黙想の1.21.4移植

## やったこと
黙想システム部分をそのまま移植
演出の音をmasterからplayerに

## やってないこと
マルチでの検証

## テスト
ソロにてすべてのレベルで動作することを確認

## レビュー観点
想定通りに動作するか？

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
