### PR TITLE
転職時のトグルスキルのリセット処理 

### DIFF
--- a/data/skill/function/toggle_reset.mcfunction
+++ b/data/skill/function/toggle_reset.mcfunction
@@ -1,0 +1,11 @@
+#> skill:toggle_reset
+#
+# 転職時トグルスキルリセット
+execute store result score _ _ run scoreboard players reset @s[scores={ReactiveLevel=1..}] ReactiveLevel
+execute if score _ _ matches 1 run function makeup:skill/act/knight/reactive_heal/toggle
+execute store result score _ _ run scoreboard players reset @s[scores={TsuremaiLevel=1..}] TsuremaiLevel
+execute if score _ _ matches 1 run function makeup:skill/act/ninja/tsuremai/toggle
+execute store result score _ _ run scoreboard players reset @s[scores={ChoyakuLevel=1..}] ChoyakuLevel
+execute if score _ _ matches 1 run function makeup:skill/act/ninja/choyaku/toggle
+execute store result score _ _ run scoreboard players reset @s[scores={WildHealing=1..}] WildHealing
+execute if score _ _ matches 1 run function makeup:skill/act/hunter/wild_healing/toggle


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-895
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
skill:toggle_resetを1.21.4に移植した。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
サヨナラの削除
## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
debug以下の職業変更処理は追記していません。後々テコ入れする予定です。
## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
job/change実行時、正常にトグルスキルがリセットすることを確認した

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->