### PR TITLE
スポナー破壊処理を追加

### DIFF
--- a/data/enemy/function/break_spawner/.mcfunction
+++ b/data/enemy/function/break_spawner/.mcfunction
@@ -1,0 +1,15 @@
+#> enemy:break_spawner/
+
+#スポナー破壊時
+# 初破壊時にマルチ補正
+    execute unless entity @s[tag=MultiplyInit] unless entity @e[type=item,nbt={Item:{components:{"minecraft:custom_data":{ExplodedLodestone:1b}}}}] if entity @e[distance=..2,type=item,nbt={Item:{components:{"minecraft:custom_data":{DamageItem:1b}}}}] run function enemy:break_spawner/multiply_count
+
+#採掘時はドロップなし 採掘時以外はロードストーンがドロップ
+#採掘時と爆破時で分岐
+execute unless entity @e[type=item,nbt={Item:{components:{"minecraft:custom_data":{ExplodedLodestone:1b}}}}] run function enemy:break_spawner/enemy_count
+execute as @e[type=item,nbt={Item:{components:{"minecraft:custom_data":{ExplodedLodestone:1b}}}}] run function enemy:break_spawner/exploded
+
+#設置したスポナーにデータをmergeする
+data modify block ~ ~ ~ {} merge from entity @s item.components."minecraft:custom_data".Spawner
+execute if entity @s[tag=Failed] run data modify block ~ ~ ~ Delay set value 200s
+tag @s remove Failed

--- a/data/enemy/function/break_spawner/break.mcfunction
+++ b/data/enemy/function/break_spawner/break.mcfunction
@@ -1,0 +1,9 @@
+#> enemy:break_spawner/break
+
+#スポナー削除
+tag @e[distance=..0.1,tag=Spawner] add Garbage
+#経験値を出す
+execute store result score _ _ run data get entity @s item.components."minecraft:custom_data".Experience
+execute if score _ _ matches 1.. run function enemy:break_spawner/give_exp
+#演出
+function makeup:enemy/break_spawner/

--- a/data/enemy/function/break_spawner/count_down.mcfunction
+++ b/data/enemy/function/break_spawner/count_down.mcfunction
@@ -1,0 +1,9 @@
+#> enemy:break_spawner/count_down
+
+# setblock ~ ~ ~ lodestone replace
+setblock ~ ~ ~ spawner destroy
+
+#ダメージ表示
+data modify storage popup: data set value {prefix:'" "',duration:0.5,value_prefix:'< ',value_suffix:' >',format:'{"text":"","color":"#FB80F8"}',size:1.0}
+execute store result storage popup: data.value int 1 run scoreboard players get _ _
+execute positioned ~ ~1.35 ~ run function #popup:

--- a/data/enemy/function/break_spawner/damage_score_get.mcfunction
+++ b/data/enemy/function/break_spawner/damage_score_get.mcfunction
@@ -1,0 +1,8 @@
+#> enemy:break_spawner/damage_score_get
+#
+# Itemからダメージ量を取得する
+#
+# @within function enemy:break_spawner/mined
+
+execute store result score _ Calc run data get entity @s Item.components."minecraft:custom_data".SpawnerDamage
+kill @s

--- a/data/enemy/function/break_spawner/enemy_count.mcfunction
+++ b/data/enemy/function/break_spawner/enemy_count.mcfunction
@@ -1,0 +1,14 @@
+#> enemy:break_spawner/enemy_count
+#
+# 敵の数をカウントする
+#
+# @within function enemy:break_spawner/
+
+# 敵の数カウント
+    execute store result score _ Calc if entity @e[distance=..12,tag=Enemy,tag=!Garbage]
+
+# エンティティが一定数より多ければ破壊失敗
+    execute unless score _ Calc matches ..15 run function enemy:break_spawner/failed_mine
+
+# エンティティが一定数以下であれば破壊処理に入る
+    execute if score _ Calc matches ..15 run function enemy:break_spawner/mined

--- a/data/enemy/function/break_spawner/enemy_count.mcfunction
+++ b/data/enemy/function/break_spawner/enemy_count.mcfunction
@@ -5,7 +5,7 @@
 # @within function enemy:break_spawner/
 
 # 敵の数カウント
-    execute store result score _ Calc if entity @e[distance=..12,tag=Enemy,tag=!Garbage]
+    execute store result score _ Calc if entity @e[distance=..8,tag=Enemy,tag=!Garbage]
 
 # エンティティが一定数より多ければ破壊失敗
     execute unless score _ Calc matches ..15 run function enemy:break_spawner/failed_mine

--- a/data/enemy/function/break_spawner/exploded.mcfunction
+++ b/data/enemy/function/break_spawner/exploded.mcfunction
@@ -1,0 +1,8 @@
+#> enemy:break_spawner/exploded
+
+#スポナー爆破時 無効化
+#同時爆破ではアイテムが消えて回避される
+kill @s
+# setblock ~ ~ ~ lodestone replace
+setblock ~ ~ ~ spawner destroy
+function makeup:enemy/break_spawner/exploded

--- a/data/enemy/function/break_spawner/failed_mine.mcfunction
+++ b/data/enemy/function/break_spawner/failed_mine.mcfunction
@@ -1,0 +1,39 @@
+#> enemy:break_spawner/failed_mine
+#
+# 復元処理
+#
+# @within function enemy:break_spawner/enemy_count
+
+# アイテムキル
+    execute as @e[distance=..2,type=item,nbt={Item:{components:{"minecraft:custom_data":{DamageItem:1b}}}},sort=nearest,limit=1] run kill @s
+
+# カウントが減っていないことを表示
+    execute store result score _ _ run data get entity @s item.components."minecraft:custom_data".Count 1
+    setblock ~ ~ ~ spawner destroy
+# ダメージ表示
+    data modify storage popup: data set value {prefix:'" "',duration:0.5,value_prefix:'< ',value_suffix:' >',format:'{"text":"","color":"#BBBBBB"}',size:1.0}
+    execute store result storage popup: data.value int 1 run scoreboard players get _ _
+    execute positioned ~ ~1.35 ~ run function #popup:
+
+# 岩盤化済みのスポナーを破壊したらメッセージで教える
+    execute if entity @e[tag=FailedMine,distance=..0.01] run tellraw @a[distance=..8] {"translate":"周囲の敵によってスポナー破壊を妨害された！","color":"#FF5555"}
+
+# 岩盤のブロックをかぶせることで壊せないことを表示
+# この対応は他で真似しない方がいいよ
+    summon minecraft:item_display ~ ~ ~ {Tags:["Spawner","FailedMine","HasAI"],glow_color_override:-1,shadow_radius:0f,billboard:"fixed",shadow_strength:1f,width:0f,height:0f,item_display:"none",view_range:1f,transformation:{translation:[0f,0f,0f],left_rotation:[0f,0f,0f,1f],right_rotation:[0f,0f,0f,1f],scale:[1.02f,1.02f,1.02f]},item:{id:"bedrock",count:1,components:{enchantment_glint_override:true}}}
+    execute as @e[distance=..0.01,tag=FailedMine,tag=!Initialized] run function #oh_my_dat:please
+    data modify storage mob_data: AI set value {TurnCount:1,Turn:[{Index:1,Skill:[{Interval:{Current:50},Loop:{Current:1},Call:[{Name:"kill"}]}]}]}
+    execute as @e[distance=..0.01,tag=FailedMine,tag=!Initialized] run function ai:turn/preparation
+    data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].AI set from storage mob_data: AI
+
+# 岩盤化チュートリアルを達成
+    advancement grant @a[distance=..8] only advancement:tutorial/secret18
+
+# タグ付け
+    tag @s add Failed
+
+# 経験値オーブをKill
+    kill @e[distance=..2,type=experience_orb]
+
+# 演出
+    function makeup:enemy/break_spawner/failed_mine

--- a/data/enemy/function/break_spawner/give_exp.mcfunction
+++ b/data/enemy/function/break_spawner/give_exp.mcfunction
@@ -1,0 +1,5 @@
+#> enemy:break_spawner/give_exp
+
+# _ Expに与える経験値の数を記録して経験値取得処理を実行する。
+scoreboard players operation _ Exp = _ _
+execute as @a[distance=..8,limit=1,sort=nearest] at @s run function job:exp/get

--- a/data/enemy/function/break_spawner/mined.mcfunction
+++ b/data/enemy/function/break_spawner/mined.mcfunction
@@ -1,0 +1,21 @@
+#> enemy:break_spawner/mined
+
+#スポナー採掘時 item.components."minecraft:custom_data".Count>=2のときスポナー再設置
+# ピッケルの素材によって与えるダメージが変化する
+# 木：0.5　石：1　鉄：2　金：3　ダイヤ：4　ネザライト：6
+scoreboard players set _ Calc 0
+execute as @e[distance=..2,type=item,nbt={Item:{components:{"minecraft:custom_data":{DamageItem:1b}}}},sort=nearest,limit=1] run function enemy:break_spawner/damage_score_get
+execute store result score _ _ run data get entity @s item.components."minecraft:custom_data".Count 10
+scoreboard players operation _ _ -= _ Calc
+scoreboard players set _ Calc 10
+scoreboard players operation # _ = _ _
+scoreboard players operation # _ %= _ Calc
+execute if score # _ matches 1.. run scoreboard players add _ _ 10
+execute store result entity @s item.components."minecraft:custom_data".Count float 1 run scoreboard players operation _ _ /= _ Calc
+execute if score _ _ matches 1.. run function enemy:break_spawner/count_down
+execute unless score _ _ matches 1.. run function enemy:break_spawner/break
+
+#経験値オーブをKill
+kill @e[distance=..2,type=experience_orb]
+# 岩盤演出をkill
+tag @e[distance=..0.1,tag=FailedMine] add Garbage

--- a/data/enemy/function/break_spawner/multiply_count.mcfunction
+++ b/data/enemy/function/break_spawner/multiply_count.mcfunction
@@ -1,0 +1,19 @@
+#> enemy:break_spawner/multiply_count
+#
+# 周囲128m以内にいるプレイヤーの数によってHPを変動
+#
+# @within function enemy:break_spawner/
+
+# マルチ補正倍率の計算 0.25 * N(人数) + 0.75
+    execute store result score _ _ if entity @a[scores={Age=1..},predicate=entity:player,distance=..128]
+    scoreboard players set _ Calc 25
+    scoreboard players operation _ _ *= _ Calc
+    scoreboard players set _ Calc 75
+    scoreboard players operation _ _ += _ Calc
+    scoreboard players set _ Calc 500
+    scoreboard players operation _ _ < _ Calc
+    execute store result score _ Calc run data get entity @s item.components."minecraft:custom_data".Count
+    execute store result entity @s item.components."minecraft:custom_data".Count int 0.01 run scoreboard players operation _ _ *= _ Calc
+
+# マルチ補正初期化タグ追加
+    tag @s add MultiplyInit

--- a/data/main/function/tick.mcfunction
+++ b/data/main/function/tick.mcfunction
@@ -20,6 +20,8 @@ function entity:tick
 
 ### Mob tick
 execute as @e[tag=Mob] at @s run function enemy:tick
+### スポナーカート空気時処理
+execute as @e[tag=SpawnerHolder] at @s unless block ~ ~ ~ minecraft:spawner run function enemy:break_spawner/
 
   ### デバッグ用 ###
   execute if data storage main: difficult{world:"debug"} run function debug:ai/usage_rate_1

--- a/data/makeup/function/enemy/break_spawner/.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/.mcfunction
@@ -1,0 +1,2 @@
+playsound minecraft:entity.zombie_villager.cure master @a[distance=..16] ~ ~ ~ 0.5 1
+particle minecraft:soul ~ ~0.5 ~ 0 0 0 0.1 14 force

--- a/data/makeup/function/enemy/break_spawner/.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/.mcfunction
@@ -1,2 +1,3 @@
+#> makeup:enemy/break_spawner/
 playsound minecraft:entity.zombie_villager.cure master @a[distance=..16] ~ ~ ~ 0.5 1
 particle minecraft:soul ~ ~0.5 ~ 0 0 0 0.1 14 force

--- a/data/makeup/function/enemy/break_spawner/.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/.mcfunction
@@ -1,3 +1,3 @@
 #> makeup:enemy/break_spawner/
-playsound minecraft:entity.zombie_villager.cure master @a[distance=..16] ~ ~ ~ 0.5 1
+playsound minecraft:entity.zombie_villager.cure block @a[distance=..16] ~ ~ ~ 0.5 1
 particle minecraft:soul ~ ~0.5 ~ 0 0 0 0.1 14 force

--- a/data/makeup/function/enemy/break_spawner/double_break.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/double_break.mcfunction
@@ -1,0 +1,2 @@
+particle minecraft:soul ~ ~0.5 ~ 0 0 0 0.2 4 force
+playsound minecraft:entity.wither.hurt master @a ~ ~ ~ 0.5 2

--- a/data/makeup/function/enemy/break_spawner/double_break.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/double_break.mcfunction
@@ -1,3 +1,3 @@
 #> makeup:enemy/break_spawner/double_break
 particle minecraft:soul ~ ~0.5 ~ 0 0 0 0.2 4 force
-playsound minecraft:entity.wither.hurt master @a ~ ~ ~ 0.5 2
+playsound minecraft:entity.wither.hurt block @a ~ ~ ~ 0.5 2

--- a/data/makeup/function/enemy/break_spawner/double_break.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/double_break.mcfunction
@@ -1,2 +1,3 @@
+#> makeup:enemy/break_spawner/double_break
 particle minecraft:soul ~ ~0.5 ~ 0 0 0 0.2 4 force
 playsound minecraft:entity.wither.hurt master @a ~ ~ ~ 0.5 2

--- a/data/makeup/function/enemy/break_spawner/exploded.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/exploded.mcfunction
@@ -1,0 +1,2 @@
+particle minecraft:lava ~ ~1 ~ 0 0.5 0 1 10 force
+particle minecraft:angry_villager ~ ~1 ~ 0 0.5 0 1 2 force

--- a/data/makeup/function/enemy/break_spawner/exploded.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/exploded.mcfunction
@@ -1,2 +1,3 @@
+#> makeup:enemy/break_spawner/exploded
 particle minecraft:lava ~ ~1 ~ 0 0.5 0 1 10 force
 particle minecraft:angry_villager ~ ~1 ~ 0 0.5 0 1 2 force

--- a/data/makeup/function/enemy/break_spawner/failed_mine.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/failed_mine.mcfunction
@@ -1,0 +1,2 @@
+playsound minecraft:item.trident.return master @a ~ ~ ~ 1.0 0.8 0.0
+playsound block.small_amethyst_bud.break master @a ~ ~ ~ 1.0 0.5

--- a/data/makeup/function/enemy/break_spawner/failed_mine.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/failed_mine.mcfunction
@@ -1,2 +1,3 @@
+#> makeup:enemy/break_spawner/failed_mine
 playsound minecraft:item.trident.return master @a ~ ~ ~ 1.0 0.8 0.0
 playsound block.small_amethyst_bud.break master @a ~ ~ ~ 1.0 0.5

--- a/data/makeup/function/enemy/break_spawner/failed_mine.mcfunction
+++ b/data/makeup/function/enemy/break_spawner/failed_mine.mcfunction
@@ -1,3 +1,3 @@
 #> makeup:enemy/break_spawner/failed_mine
-playsound minecraft:item.trident.return master @a ~ ~ ~ 1.0 0.8 0.0
-playsound block.small_amethyst_bud.break master @a ~ ~ ~ 1.0 0.5
+playsound minecraft:item.trident.return block @a ~ ~ ~ 1.0 0.8 0.0
+playsound block.small_amethyst_bud.break block @a ~ ~ ~ 1.0 0.5


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-911
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
スポナーを破壊したときの処理を追加しました
破壊したときにスポナーの敵が出現する。
周囲に多くの敵がいるときに破壊が妨害される。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* `tag` -> `components."custom_data"`
* 破壊失敗時の岩盤へAIを付与するときの処理

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
スポナー配置シートのスポナーどれでもテストできます。

## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->
コミットの粒度が荒くてすんません
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
