### PR TITLE
エンティティ削除時にデータをマージするコマンドを変更

### DIFF
--- a/data/entity/function/garbage_collection.mcfunction
+++ b/data/entity/function/garbage_collection.mcfunction
@@ -9,6 +9,6 @@ execute if entity @s[tag=!Garbage] run return fail
 
 execute if entity @s[tag=Parent] run function entity:kill_child
 execute if entity @s[tag=LifeScouter] on passengers if entity @s[tag=LifeScouterText] run kill @s
-data merge entity @s {Health:0f,Size:0,DeathTime:19s,HandItems:[{},{}],ArmorItems:[{},{},{},{}],Owner:[I;0,0,0,0]}
+data modify entity @s {} merge value {Health:0f,Size:0,DeathTime:19s,HandItems:[{},{}],ArmorItems:[{},{},{},{}],Owner:[I;0,0,0,0]}
 data remove entity @s CustomName
 kill @s


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
NO-ISSUE
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
```mcfunction
#> entity:garbage_collection
data merge entity @s {Health:0f,Size:0,DeathTime:19s,HandItems:[{},{}],ArmorItems:[{},{},{},{}],Owner:[I;0,0,0,0]}
```

<img width="1254" height="175" alt="image" src="https://github.com/user-attachments/assets/2baed3d5-4d58-4061-a0bd-d0a548443ea3" />  

VSCodeかつDatapack Helper Plusで開発をしてたらここのファイルからエラー出しててうざくない？？  
うざくない？  
そう……  
じゃあ  
クローズしてもいいよ
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
```mcfunction
data modify entity @s {} merge value {Health:0f,Size:0,DeathTime:19s,HandItems:[{},{}],ArmorItems:[{},{},{},{}],Owner:[I;0,0,0,0]}
```
こうしたらエラーは出なくなった。
これでも同じ動作はするよね

## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->
nbt-docを使えば抑制できないかと思ったが、全エンティティにこのデータを持っていると示す方法がわからない。というか、既に定義済みだよって言われた……
https://github.com/Yurihaia/nbtdoc-rs/blob/master/docs/format.md
https://spyglassmc.com/user/mcdoc/

ストレージの構造整理もこれでしてみたいという独り言
でもストレージってかなり自由だからこれで縛るのは得策ではない気も……
構造がはっきりしてるものぐらいは考えてもいいかもぐらい
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
