### PR TITLE
無敵額縁をはがす機能を追加

### DIFF
--- a/data/entity/advancement/item_frames.json
+++ b/data/entity/advancement/item_frames.json
@@ -1,0 +1,72 @@
+{
+  "criteria": {
+    "item_frame": {
+      "trigger": "minecraft:player_interacted_with_entity",
+      "conditions": {
+        "entity": {
+          "type": "item_frame"
+        },
+        "player": [
+          {
+            "condition": "entity_properties",
+            "entity": "this",
+            "predicate": {
+              "flags": {
+                "is_sneaking": true
+              }
+            }
+          },
+          {
+            "condition": "inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "adventure"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "glow_item_frame": {
+      "trigger": "minecraft:player_interacted_with_entity",
+      "conditions": {
+        "entity": {
+          "type": "glow_item_frame"
+        },
+        "player": [
+          {
+            "condition": "entity_properties",
+            "entity": "this",
+            "predicate": {
+              "flags": {
+                "is_sneaking": true
+              }
+            }
+          },
+          {
+            "condition": "inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type_specific": {
+                  "type": "player",
+                  "gamemode": "adventure"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "requirements":[["item_frame","glow_item_frame"]],
+  "rewards": {
+    "function": "entity:item_frame_destroy/item_frames"
+  }
+}

--- a/data/entity/advancement/item_frames.json
+++ b/data/entity/advancement/item_frames.json
@@ -1,52 +1,22 @@
 {
   "criteria": {
     "item_frame": {
-      "trigger": "minecraft:player_interacted_with_entity",
+      "trigger": "minecraft:tick",
       "conditions": {
-        "entity": {
-          "type": "item_frame"
-        },
         "player": [
           {
-            "condition": "entity_properties",
-            "entity": "this",
-            "predicate": {
-              "flags": {
-                "is_sneaking": true
-              }
-            }
+            "condition": "reference",
+            "name": "entity:item_frama_destroy/looking_item_frame"
           },
           {
-            "condition": "inverted",
-            "term": {
-              "condition": "minecraft:entity_properties",
-              "entity": "this",
-              "predicate": {
-                "type_specific": {
-                  "type": "player",
-                  "gamemode": [
-                    "adventure"
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      }
-    },
-    "glow_item_frame": {
-      "trigger": "minecraft:player_interacted_with_entity",
-      "conditions": {
-        "entity": {
-          "type": "glow_item_frame"
-        },
-        "player": [
-          {
-            "condition": "entity_properties",
+            "condition": "minecraft:entity_properties",
             "entity": "this",
             "predicate": {
-              "flags": {
-                "is_sneaking": true
+              "type_specific": {
+                "type": "player",
+                "looking_at": {
+                  "nbt": "{Invulnerable:true}"
+                }
               }
             }
           },
@@ -71,8 +41,7 @@
   },
   "requirements": [
     [
-      "item_frame",
-      "glow_item_frame"
+      "item_frame"
     ]
   ],
   "rewards": {

--- a/data/entity/advancement/item_frames.json
+++ b/data/entity/advancement/item_frames.json
@@ -5,16 +5,13 @@
       "conditions": {
         "player": [
           {
-            "condition": "reference",
-            "name": "entity:item_frama_destroy/looking_item_frame"
-          },
-          {
             "condition": "minecraft:entity_properties",
             "entity": "this",
             "predicate": {
               "type_specific": {
                 "type": "player",
                 "looking_at": {
+                  "type": "#entity:item_frames",
                   "nbt": "{Invulnerable:true}"
                 }
               }

--- a/data/entity/advancement/item_frames.json
+++ b/data/entity/advancement/item_frames.json
@@ -24,7 +24,9 @@
               "predicate": {
                 "type_specific": {
                   "type": "player",
-                  "gamemode": "adventure"
+                  "gamemode": [
+                    "adventure"
+                  ]
                 }
               }
             }
@@ -56,7 +58,9 @@
               "predicate": {
                 "type_specific": {
                   "type": "player",
-                  "gamemode": "adventure"
+                  "gamemode": [
+                    "adventure"
+                  ]
                 }
               }
             }
@@ -65,7 +69,12 @@
       }
     }
   },
-  "requirements":[["item_frame","glow_item_frame"]],
+  "requirements": [
+    [
+      "item_frame",
+      "glow_item_frame"
+    ]
+  ],
   "rewards": {
     "function": "entity:item_frame_destroy/item_frames"
   }

--- a/data/entity/function/item_frame_destroy/detach.mcfunction
+++ b/data/entity/function/item_frame_destroy/detach.mcfunction
@@ -1,3 +1,4 @@
+#> entity:item_frame_destroy/detach
 summon item ~ ~ ~ {Item:{id:"stick",Count:1b,tag:{CustomModelData:1}},Motion:[0d,0.2d,0d]}
 data modify entity @e[type=item,distance=0,limit=1] Item set from entity @s Item
 item replace entity @s container.0 with air

--- a/data/entity/function/item_frame_destroy/detach.mcfunction
+++ b/data/entity/function/item_frame_destroy/detach.mcfunction
@@ -1,4 +1,0 @@
-#> entity:item_frame_destroy/detach
-summon item ~ ~ ~ {Item:{id:"stick",count:1b,components:{"minecraft:custom_data":1}},Motion:[0d,0.2d,0d]}
-data modify entity @e[type=item,distance=0,limit=1] Item set from entity @s Item
-item replace entity @s container.0 with air

--- a/data/entity/function/item_frame_destroy/detach.mcfunction
+++ b/data/entity/function/item_frame_destroy/detach.mcfunction
@@ -1,4 +1,4 @@
 #> entity:item_frame_destroy/detach
-summon item ~ ~ ~ {Item:{id:"stick",Count:1b,tag:{CustomModelData:1}},Motion:[0d,0.2d,0d]}
+summon item ~ ~ ~ {Item:{id:"stick",count:1b,components:{"minecraft:custom_data":1}},Motion:[0d,0.2d,0d]}
 data modify entity @e[type=item,distance=0,limit=1] Item set from entity @s Item
 item replace entity @s container.0 with air

--- a/data/entity/function/item_frame_destroy/detach.mcfunction
+++ b/data/entity/function/item_frame_destroy/detach.mcfunction
@@ -1,0 +1,3 @@
+summon item ~ ~ ~ {Item:{id:"stick",Count:1b,tag:{CustomModelData:1}},Motion:[0d,0.2d,0d]}
+data modify entity @e[type=item,distance=0,limit=1] Item set from entity @s Item
+item replace entity @s container.0 with air

--- a/data/entity/function/item_frame_destroy/item_frames.mcfunction
+++ b/data/entity/function/item_frame_destroy/item_frames.mcfunction
@@ -1,0 +1,9 @@
+#> entity:item_frame_destroy/item_frames
+
+# 探索距離7ブロック
+    scoreboard players set _ _ 70
+
+# 視線先のスポナーを探索
+    execute anchored eyes positioned ^ ^ ^ run function entity:item_frame_destroy/search
+
+advancement revoke @s only entity:item_frames

--- a/data/entity/function/item_frame_destroy/item_frames.mcfunction
+++ b/data/entity/function/item_frame_destroy/item_frames.mcfunction
@@ -1,9 +1,9 @@
 #> entity:item_frame_destroy/item_frames
 
 # 探索距離7ブロック
-    scoreboard players set _ _ 70
+data modify storage calc: SearchForward set value {Loop:7d,Stop:[Block]}
+execute anchored eyes positioned ^ ^ ^ anchored feet run function calc:geometry/search_forward/
 
-# 視線先の額縁を探索
-    execute anchored eyes positioned ^ ^ ^ run function entity:item_frame_destroy/search
+execute at 0-0-0-0-0 run function entity:item_frame_destroy/search
 
 schedule function entity:item_frame_destroy/schedule 1t

--- a/data/entity/function/item_frame_destroy/item_frames.mcfunction
+++ b/data/entity/function/item_frame_destroy/item_frames.mcfunction
@@ -3,7 +3,7 @@
 # 探索距離7ブロック
     scoreboard players set _ _ 70
 
-# 視線先のスポナーを探索
+# 視線先の額縁を探索
     execute anchored eyes positioned ^ ^ ^ run function entity:item_frame_destroy/search
 
 advancement revoke @s only entity:item_frames

--- a/data/entity/function/item_frame_destroy/item_frames.mcfunction
+++ b/data/entity/function/item_frame_destroy/item_frames.mcfunction
@@ -6,4 +6,4 @@
 # 視線先の額縁を探索
     execute anchored eyes positioned ^ ^ ^ run function entity:item_frame_destroy/search
 
-advancement revoke @s only entity:item_frames
+schedule function entity:item_frame_destroy/schedule 1t

--- a/data/entity/function/item_frame_destroy/reactivate.mcfunction
+++ b/data/entity/function/item_frame_destroy/reactivate.mcfunction
@@ -3,5 +3,5 @@
 # 額縁無敵 再有効化
 #
 
-execute as @e[type=#entity:item_frames] run data modify entity @s Invulnerable set value 1b
+execute as @e[type=#entity:item_frames,distance=..8] run data modify entity @s Invulnerable set value 1b
 advancement revoke @s only entity:item_frames

--- a/data/entity/function/item_frame_destroy/reactivate.mcfunction
+++ b/data/entity/function/item_frame_destroy/reactivate.mcfunction
@@ -4,4 +4,6 @@
 #
 
 execute as @e[type=#entity:item_frames,distance=..8] run data modify entity @s Invulnerable set value 1b
+stopsound @s * minecraft:entity.item_frame.add_item
+stopsound @s * minecraft:entity.glow_item_frame.add_item
 advancement revoke @s only entity:item_frames

--- a/data/entity/function/item_frame_destroy/reactivate.mcfunction
+++ b/data/entity/function/item_frame_destroy/reactivate.mcfunction
@@ -1,0 +1,7 @@
+#> entity:item_frame_destroy/reactivate
+#
+# 額縁無敵 再有効化
+#
+
+execute as @e[type=#entity:item_frames] run data modify entity @s Invulnerable set value 1b
+advancement revoke @s only entity:item_frames

--- a/data/entity/function/item_frame_destroy/schedule.mcfunction
+++ b/data/entity/function/item_frame_destroy/schedule.mcfunction
@@ -1,3 +1,3 @@
 #> entity:item_frame_destroy/schedule
-execute as @a[advancements={entity:item_frames=true}] unless predicate entity:item_frama_destroy/looking_item_frame run function entity:item_frame_destroy/reactivate
-execute as @a[advancements={entity:item_frames=true}] if predicate entity:item_frama_destroy/looking_item_frame run schedule function entity:item_frame_destroy/schedule 2t
+execute as @a[advancements={entity:item_frames=true}] at @s unless predicate entity:item_frama_destroy/looking_item_frame run function entity:item_frame_destroy/reactivate
+execute as @a[advancements={entity:item_frames=true}] at @s if predicate entity:item_frama_destroy/looking_item_frame run schedule function entity:item_frame_destroy/schedule 2t

--- a/data/entity/function/item_frame_destroy/schedule.mcfunction
+++ b/data/entity/function/item_frame_destroy/schedule.mcfunction
@@ -1,0 +1,3 @@
+#> entity:item_frame_destroy/schedule
+execute as @a[advancements={entity:item_frames=true}] unless predicate entity:item_frama_destroy/looking_item_frame run function entity:item_frame_destroy/reactivate
+execute as @a[advancements={entity:item_frames=true}] if predicate entity:item_frama_destroy/looking_item_frame run schedule function entity:item_frame_destroy/schedule 2t

--- a/data/entity/function/item_frame_destroy/search.mcfunction
+++ b/data/entity/function/item_frame_destroy/search.mcfunction
@@ -1,0 +1,13 @@
+#> entity:item_frame_destroy/search
+
+#視線先のスポナーを探索
+scoreboard players remove _ _ 1
+execute if score _ _ matches 1.. unless entity @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] positioned ^ ^ ^0.1 run function entity:item_frame_destroy/search
+
+# アイテムが飾られていなければ額縁を撤去
+execute if entity @s[advancements={entity:item_frames={item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"item_frame",Count:1b},Motion:[0d,0.2d,0d]}
+execute if entity @s[advancements={entity:item_frames={glow_item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"glow_item_frame",Count:1b},Motion:[0d,0.2d,0d]}
+execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run kill @s
+
+# アイテムが飾られていれば飾られているアイテムを排出
+execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] if data entity @s Item at @s positioned ^ ^ ^0.1 run function entity:item_frame_destroy/detach

--- a/data/entity/function/item_frame_destroy/search.mcfunction
+++ b/data/entity/function/item_frame_destroy/search.mcfunction
@@ -5,8 +5,8 @@ scoreboard players remove _ _ 1
 execute if score _ _ matches 1.. unless entity @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] positioned ^ ^ ^0.1 run function entity:item_frame_destroy/search
 
 # アイテムが飾られていなければ額縁を撤去
-execute if entity @s[advancements={entity:item_frames={item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"item_frame",Count:1b},Motion:[0d,0.2d,0d]}
-execute if entity @s[advancements={entity:item_frames={glow_item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"glow_item_frame",Count:1b},Motion:[0d,0.2d,0d]}
+execute if entity @s[advancements={entity:item_frames={item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"item_frame",count:1},Motion:[0d,0.2d,0d]}
+execute if entity @s[advancements={entity:item_frames={glow_item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"glow_item_frame",count:1},Motion:[0d,0.2d,0d]}
 execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run kill @s
 
 # アイテムが飾られていれば飾られているアイテムを排出

--- a/data/entity/function/item_frame_destroy/search.mcfunction
+++ b/data/entity/function/item_frame_destroy/search.mcfunction
@@ -5,9 +5,4 @@ scoreboard players remove _ _ 1
 execute if score _ _ matches 1.. unless entity @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] positioned ^ ^ ^0.1 run function entity:item_frame_destroy/search
 
 # アイテムが飾られていなければ額縁を撤去
-execute if entity @s[advancements={entity:item_frames={item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"item_frame",count:1},Motion:[0d,0.2d,0d]}
-execute if entity @s[advancements={entity:item_frames={glow_item_frame=true}}] as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run summon item ~ ~ ~ {Item:{id:"glow_item_frame",count:1},Motion:[0d,0.2d,0d]}
-execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] unless data entity @s Item run kill @s
-
-# アイテムが飾られていれば飾られているアイテムを排出
-execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] if data entity @s Item at @s positioned ^ ^ ^0.1 run function entity:item_frame_destroy/detach
+execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] run data modify entity @s Invulnerable set value 0b

--- a/data/entity/function/item_frame_destroy/search.mcfunction
+++ b/data/entity/function/item_frame_destroy/search.mcfunction
@@ -4,5 +4,5 @@
 scoreboard players remove _ _ 1
 execute if score _ _ matches 1.. unless entity @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] positioned ^ ^ ^0.1 run function entity:item_frame_destroy/search
 
-# アイテムが飾られていなければ額縁を撤去
+# 額縁の無敵を解除
 execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] run data modify entity @s Invulnerable set value 0b

--- a/data/entity/function/item_frame_destroy/search.mcfunction
+++ b/data/entity/function/item_frame_destroy/search.mcfunction
@@ -1,4 +1,7 @@
 #> entity:item_frame_destroy/search
 
 # 額縁の無敵を解除
-execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] run data modify entity @s Invulnerable set value 0b
+execute as @e[type=#entity:item_frames,distance=..1,sort=nearest,limit=1] run data modify entity @s Invulnerable set value 0b
+
+stopsound @s * minecraft:entity.item_frame.add_item
+stopsound @s * minecraft:entity.glow_item_frame.add_item

--- a/data/entity/function/item_frame_destroy/search.mcfunction
+++ b/data/entity/function/item_frame_destroy/search.mcfunction
@@ -1,8 +1,4 @@
 #> entity:item_frame_destroy/search
 
-#視線先のスポナーを探索
-scoreboard players remove _ _ 1
-execute if score _ _ matches 1.. unless entity @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] positioned ^ ^ ^0.1 run function entity:item_frame_destroy/search
-
 # 額縁の無敵を解除
 execute as @e[type=#entity:item_frames,distance=..0.25,sort=nearest,limit=1] run data modify entity @s Invulnerable set value 0b

--- a/data/entity/predicate/item_frama_destroy/looking_item_frame.json
+++ b/data/entity/predicate/item_frama_destroy/looking_item_frame.json
@@ -1,0 +1,12 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "type_specific": {
+      "type": "player",
+      "looking_at": {
+        "type": "#entity:item_frames"
+      }
+    }
+  }
+}

--- a/data/entity/predicate/item_frama_destroy/looking_item_frame.json
+++ b/data/entity/predicate/item_frama_destroy/looking_item_frame.json
@@ -5,7 +5,8 @@
     "type_specific": {
       "type": "player",
       "looking_at": {
-        "type": "#entity:item_frames"
+        "type": "#entity:item_frames",
+        "nbt": "{Invulnerable:false}"
       }
     }
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-920
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
額縁と光る額縁は、爆風に耐えられるように無敵(`Invulnerable`)が有効になっている。
このままでは額縁の中のアイテムや額縁をはがすことができないため、その対応を行う
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* 視線を向けた時にその額縁の無敵化を解除する

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
チェストが密集しているような額縁の配置でも正しい額縁の無敵が無効化されることを確認する

```mcfunction
execute as @e[type=#entity:item_frames] run data modify entity @s Glowing set from entity @s Invulnerable
```
うるさいけどこれでチェックしやすいと思います
## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->
額縁を見た時、もしくはみるのをやめた時に、アイテムをはめた時の音が鳴る。額縁を指せたかどうかの確認サウンドとして残すのもアリか？

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
