### PR TITLE
照明弾の1.21.4移植

### DIFF
--- a/data/makeup/function/skill/act/hunter/flare_bomb/act0.mcfunction
+++ b/data/makeup/function/skill/act/hunter/flare_bomb/act0.mcfunction
@@ -1,0 +1,8 @@
+#> makeup:skill/act/hunter/flare_bomb/act0
+#
+# 照明弾発動
+
+summon minecraft:firework_rocket ~ ~1 ~ {LifeTime:32,FireworksItem:{id:"minecraft:firework_rocket",count:1b,components:{fireworks:{explosions:[{shape:"small_ball",has_trail:1b,colors:[I;16711680],fade_colors:[I;16753152]},{shape:"small_ball",has_trail:1b,colors:[I;16753152],fade_colors:[I;16711680]}]}}}}
+playsound minecraft:entity.firework_rocket.launch player @a[distance=..32] ~ ~ ~ 1 0.55
+playsound minecraft:entity.player.hurt_on_fire player @a[distance=..32] ~ ~ ~ 3 0
+execute rotated ~ 0 run particle minecraft:flame ^ ^1 ^1 0.1 1 0.1 0.05 10 force

--- a/data/makeup/function/skill/act/hunter/flare_bomb/act0.mcfunction
+++ b/data/makeup/function/skill/act/hunter/flare_bomb/act0.mcfunction
@@ -2,7 +2,7 @@
 #
 # 照明弾発動
 
-summon minecraft:firework_rocket ~ ~1 ~ {LifeTime:32,FireworksItem:{id:"minecraft:firework_rocket",count:1b,components:{fireworks:{explosions:[{shape:"small_ball",has_trail:1b,colors:[I;16711680],fade_colors:[I;16753152]},{shape:"small_ball",has_trail:1b,colors:[I;16753152],fade_colors:[I;16711680]}]}}}}
+summon minecraft:firework_rocket ~ ~1 ~ {LifeTime:32,FireworksItem:{id:"minecraft:firework_rocket",count:1,components:{fireworks:{explosions:[{shape:"small_ball",has_trail:1b,colors:[I;16711680],fade_colors:[I;16753152]},{shape:"small_ball",has_trail:1b,colors:[I;16753152],fade_colors:[I;16711680]}]}}}}
 playsound minecraft:entity.firework_rocket.launch player @a[distance=..32] ~ ~ ~ 1 0.55
 playsound minecraft:entity.player.hurt_on_fire player @a[distance=..32] ~ ~ ~ 3 0
 execute rotated ~ 0 run particle minecraft:flame ^ ^1 ^1 0.1 1 0.1 0.05 10 force

--- a/data/skill/function/act/hunter/flare_bomb/act0.mcfunction
+++ b/data/skill/function/act/hunter/flare_bomb/act0.mcfunction
@@ -1,0 +1,17 @@
+#> skill:act/hunter/flare_bomb/act0
+#
+# 照明弾発動
+
+# 暗視付与
+effect give @a[distance=..32] minecraft:night_vision 180 127
+
+# 敵に発光付与
+execute if score _ Level matches 1 run effect give @e[distance=..16,tag=Enemy] minecraft:glowing 30 127
+execute if score _ Level matches 2 run effect give @e[distance=..32,tag=Enemy] minecraft:glowing 30 127
+
+# デバフ付与
+execute if score _ Level matches 1 as @e[distance=..4,tag=Enemy] at @s run function effect:enemy_debuff/fear/apply
+execute if score _ Level matches 2 as @e[distance=..8,tag=Enemy] at @s run function effect:enemy_debuff/fear/apply
+
+# 演出
+function makeup:skill/act/hunter/flare_bomb/act0

--- a/data/skill/function/act/hunter/flare_bomb/act0.mcfunction
+++ b/data/skill/function/act/hunter/flare_bomb/act0.mcfunction
@@ -10,8 +10,8 @@ execute if score _ Level matches 1 run effect give @e[distance=..16,tag=Enemy] m
 execute if score _ Level matches 2 run effect give @e[distance=..32,tag=Enemy] minecraft:glowing 30 127
 
 # デバフ付与
-execute if score _ Level matches 1 as @e[distance=..4,tag=Enemy] at @s run function effect:enemy_debuff/fear/apply
-execute if score _ Level matches 2 as @e[distance=..8,tag=Enemy] at @s run function effect:enemy_debuff/fear/apply
+execute if score _ Level matches 1 as @e[distance=..3,tag=Enemy] at @s run function effect:enemy_debuff/fear/apply
+execute if score _ Level matches 2 as @e[distance=..6,tag=Enemy] at @s run function effect:enemy_debuff/fear/apply
 
 # 演出
 function makeup:skill/act/hunter/flare_bomb/act0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
GH-930

## 対応内容・対応背景・妥協点<!-- 必須 -->
照明弾を変更したうえで1.21.4に移植した。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
サウンドソースの変更
Lv1での16m発光付与
デバフ:畏怖の付与
・Lv1 3m
・Lv2 6m

## テスト<!-- なかったらこの項目を削除してください -->
自身に暗視、敵に発光を付与したのを確認

## レビュー観点
畏怖付与の記述が間違っていないか？

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
