### PR TITLE
inGroundを持つエンティティへのCooldownタイマーを改良

### DIFF
--- a/data/entity/function/check_freeze.mcfunction
+++ b/data/entity/function/check_freeze.mcfunction
@@ -4,11 +4,12 @@
 ##############################
 
 ###PortalCooldownの値が1秒前と変化していなければ、凍結していると判断して消す
-execute store result score _ ProjectileLife run data get entity @s PortalCooldown
+execute store result score @s _ run data get entity @s PortalCooldown
+execute if entity @s[type=#entity:has_in_ground,tag=!Flying] store result score @s _ run function entity:has_in_ground/get/life_to_cooldown
 
-execute if score @s ProjectileLife = _ ProjectileLife if entity @s[tag=HasSkillDisplay] on passengers run kill @s[tag=SkillDisplay]
+execute if predicate entity:check_freeze if entity @s[tag=HasSkillDisplay] on passengers run kill @s[tag=SkillDisplay]
 ###PortalCooldownを消費しきったときにのみ各種処理を実行する
-execute if score @s ProjectileLife = _ ProjectileLife unless score _ ProjectileLife matches 0 run tag @s add Garbage
-execute if score @s ProjectileLife = _ ProjectileLife if score _ ProjectileLife matches 0 run function entity:cooldown
+execute if predicate entity:check_freeze unless score @s _ matches ..0 run tag @s add Garbage
+execute if predicate entity:check_freeze if score @s _ matches ..0 run function entity:cooldown
 
-scoreboard players operation @s ProjectileLife = _ ProjectileLife
+scoreboard players operation @s ProjectileLife = @s _

--- a/data/entity/function/has_in_ground/check.mcfunction
+++ b/data/entity/function/has_in_ground/check.mcfunction
@@ -1,0 +1,8 @@
+#> entity:has_in_ground/check
+#
+# Flying かつ speed:0 -> lifeへ移行
+# not Flying かつ not speed:0 -> cooldownへ移行
+#
+
+execute if entity @s[tag=Flying] if predicate entity:has_in_ground/not_flying run return run function entity:has_in_ground/set/cooldown_to_life
+execute if entity @s[tag=!Flying] if predicate entity:has_in_ground/flying run function entity:has_in_ground/set/life_to_cooldown

--- a/data/entity/function/has_in_ground/cooldown/check/.mcfunction
+++ b/data/entity/function/has_in_ground/cooldown/check/.mcfunction
@@ -1,0 +1,11 @@
+#> entity:has_in_ground/cooldown/check/
+#
+# function entity:has_in_ground/cooldown/check/ {PortalCooldown:100}
+#   PortalCooldownにチェックする値を指定する
+#
+
+$scoreboard players set _ _ $(PortalCooldown)
+
+# 1 = true, 0 = false
+execute if entity @s[tag=Flying] run return run function entity:has_in_ground/cooldown/check/portal_cooldown
+execute unless entity @s[tag=Flying] run return run function entity:has_in_ground/cooldown/check/life

--- a/data/entity/function/has_in_ground/cooldown/check/life.mcfunction
+++ b/data/entity/function/has_in_ground/cooldown/check/life.mcfunction
@@ -1,0 +1,7 @@
+#> entity:has_in_ground/cooldown/check/life
+
+execute store result score # _ run data get entity @s life -1
+scoreboard players add # _ 1159
+# 0チェック時は、0以下も真扱いにする
+execute if score _ _ matches 0 run return run execute if score _ _ >= # _
+return run execute if score _ _ = # _

--- a/data/entity/function/has_in_ground/cooldown/check/portal_cooldown.mcfunction
+++ b/data/entity/function/has_in_ground/cooldown/check/portal_cooldown.mcfunction
@@ -1,0 +1,4 @@
+#> entity:has_in_ground/cooldown/check/portal_cooldown
+
+execute store result score # _ run data get entity @s PortalCooldown
+return run execute if score _ _ = # _

--- a/data/entity/function/has_in_ground/cooldown/set/.mcfunction
+++ b/data/entity/function/has_in_ground/cooldown/set/.mcfunction
@@ -1,0 +1,10 @@
+#> entity:has_in_ground/cooldown/set/
+#
+# function entity:has_in_ground/cooldown/set/ {PortalCooldown:100}
+#   PortalCooldownに更新値を指定する
+#
+
+$scoreboard players set _ _ $(PortalCooldown)
+
+execute if entity @s[tag=Flying] run function entity:has_in_ground/cooldown/set/portal_cooldown
+execute unless entity @s[tag=Flying] run function entity:has_in_ground/cooldown/set/life

--- a/data/entity/function/has_in_ground/cooldown/set/life.mcfunction
+++ b/data/entity/function/has_in_ground/cooldown/set/life.mcfunction
@@ -1,0 +1,23 @@
+#> entity:has_in_ground/cooldown/set/life
+
+# life
+# このfunctionが呼び出されるタイミングが不定のため、CooldownRequiredの判定時に1159を超えていないようにするための対策
+execute if score _ _ matches 0 run scoreboard players add _ _ 1
+execute store result entity @s life short -1 run scoreboard players remove _ _ 1159
+
+# PortalCooldown用のGameTime更新
+# C - (B - x) = A : 再飛行時のPortalCooldown設定式
+# x = A + B - C
+# 
+# x: @s GameTime : 変更する着弾時GameTime
+# 
+# A: _ _ : 引数のPortalCooldown
+# B: # Calc = GameTime : 現在のGameTime
+# C: _ Calc = @s PortalCooldown : 停止したときのPortalCooldown
+execute store result score # Calc run time query gametime
+execute store result score _ Calc run data get entity @s PortalCooldown
+
+scoreboard players operation _ _ += # Calc
+scoreboard players operation _ _ -= _ Calc
+
+scoreboard players operation @s GameTime = _ _

--- a/data/entity/function/has_in_ground/cooldown/set/life.mcfunction
+++ b/data/entity/function/has_in_ground/cooldown/set/life.mcfunction
@@ -1,23 +1,11 @@
 #> entity:has_in_ground/cooldown/set/life
 
+# PortalCooldown用のGameTime更新
+# 現時点から設定時間が始まるとすればよい
+execute store result score @s GameTime run time query gametime
+execute store result entity @s PortalCooldown int 1 run scoreboard players get _ _
+
 # life
 # このfunctionが呼び出されるタイミングが不定のため、CooldownRequiredの判定時に1159を超えていないようにするための対策
 execute if score _ _ matches 0 run scoreboard players add _ _ 1
 execute store result entity @s life short -1 run scoreboard players remove _ _ 1159
-
-# PortalCooldown用のGameTime更新
-# C - (B - x) = A : 再飛行時のPortalCooldown設定式
-# x = A + B - C
-# 
-# x: @s GameTime : 変更する着弾時GameTime
-# 
-# A: _ _ : 引数のPortalCooldown
-# B: # Calc = GameTime : 現在のGameTime
-# C: _ Calc = @s PortalCooldown : 停止したときのPortalCooldown
-execute store result score # Calc run time query gametime
-execute store result score _ Calc run data get entity @s PortalCooldown
-
-scoreboard players operation _ _ += # Calc
-scoreboard players operation _ _ -= _ Calc
-
-scoreboard players operation @s GameTime = _ _

--- a/data/entity/function/has_in_ground/cooldown/set/portal_cooldown.mcfunction
+++ b/data/entity/function/has_in_ground/cooldown/set/portal_cooldown.mcfunction
@@ -1,0 +1,3 @@
+#> entity:has_in_ground/cooldown/set/portal_cooldown
+
+execute store result entity @s PortalCooldown int 1 run scoreboard players get _ _

--- a/data/entity/function/has_in_ground/get/cooldown_to_life.mcfunction
+++ b/data/entity/function/has_in_ground/get/cooldown_to_life.mcfunction
@@ -1,0 +1,13 @@
+#> entity:has_in_ground/get/cooldown_to_life
+#
+# PortalCooldownの値をlifeに変換する
+# lifeの猶予は2秒=40tick
+# 返り値は変換値
+#
+
+execute store result score @s GameTime run time query gametime
+
+scoreboard players set _ Calc 1159
+execute store result score _ _ run data get entity @s PortalCooldown
+scoreboard players operation _ Calc -= _ _
+return run scoreboard players get _ Calc

--- a/data/entity/function/has_in_ground/get/life_to_cooldown.mcfunction
+++ b/data/entity/function/has_in_ground/get/life_to_cooldown.mcfunction
@@ -4,7 +4,6 @@
 # 返り値は変換値
 #
 
-scoreboard players set _ Calc 1159
-execute store result score _ _ run data get entity @s life
-scoreboard players operation _ Calc -= _ _
-return run scoreboard players get _ Calc
+execute store result score _ _ run data get entity @s life -1
+scoreboard players add _ _ 1159
+return run scoreboard players get _ _

--- a/data/entity/function/has_in_ground/get/life_to_cooldown.mcfunction
+++ b/data/entity/function/has_in_ground/get/life_to_cooldown.mcfunction
@@ -1,0 +1,10 @@
+#> entity:has_in_ground/get/life_to_cooldown
+#
+# lifeの値をPortalCooldownに変換する
+# 返り値は変換値
+#
+
+scoreboard players set _ Calc 1159
+execute store result score _ _ run data get entity @s life
+scoreboard players operation _ Calc -= _ _
+return run scoreboard players get _ Calc

--- a/data/entity/function/has_in_ground/is_garbage.mcfunction
+++ b/data/entity/function/has_in_ground/is_garbage.mcfunction
@@ -1,0 +1,11 @@
+#> entity:has_in_ground/is_garbage
+#
+# 実行エンティティがGarbage状態かどうかを確認する
+# if function で指定可能
+#
+
+scoreboard players set _ _ 0
+
+# 1 = true, 0 = false
+execute if entity @s[tag=Flying] run return run function entity:has_in_ground/cooldown/check/portal_cooldown
+execute unless entity @s[tag=Flying] run return run function entity:has_in_ground/cooldown/check/life

--- a/data/entity/function/has_in_ground/set/cooldown_to_life.mcfunction
+++ b/data/entity/function/has_in_ground/set/cooldown_to_life.mcfunction
@@ -1,0 +1,7 @@
+#> entity:has_in_ground/set/cooldown_to_life
+#
+# lifeの値をPortalCooldownからの変換値にセットする
+#
+
+tag @s remove Flying
+execute store result entity @s life short 1 run function entity:has_in_ground/get/cooldown_to_life

--- a/data/entity/function/has_in_ground/set/life_to_cooldown.mcfunction
+++ b/data/entity/function/has_in_ground/set/life_to_cooldown.mcfunction
@@ -1,0 +1,13 @@
+#> entity:has_in_ground/set/life_to_cooldown
+#
+# PortalCooldownの値に着弾後の経過時間を引いてセットする
+#
+
+tag @s add Flying
+
+execute store result score _ GameTime run time query gametime
+
+scoreboard players operation _ GameTime -= @s GameTime
+execute store result score _ _ run data get entity @s PortalCooldown
+scoreboard players operation _ _ -= _ GameTime
+execute store result entity @s PortalCooldown int 1 run scoreboard players add _ _ 1

--- a/data/entity/function/has_in_ground/transfer_check.mcfunction
+++ b/data/entity/function/has_in_ground/transfer_check.mcfunction
@@ -1,4 +1,4 @@
-#> entity:has_in_ground/check
+#> entity:has_in_ground/transfer_check
 #
 # Flying かつ speed:0 -> lifeへ移行
 # not Flying かつ not speed:0 -> cooldownへ移行

--- a/data/entity/function/initialize_projectile.mcfunction
+++ b/data/entity/function/initialize_projectile.mcfunction
@@ -3,6 +3,8 @@
 tag @s[tag=!Cargo] add TickingRequired
 tag @s add FlyingRequired
 data modify entity @s[nbt={PortalCooldown:0}] PortalCooldown set value 200
+execute if entity @s[type=#entity:has_in_ground] store result entity @s life short 1 run function entity:has_in_ground/get/cooldown_to_life
+execute if predicate entity:has_in_ground/flying run tag @s add Flying
 
 ### 矢のダメージ設定
 execute if entity @s[type=#minecraft:arrows,nbt={pickup:0b}] unless score @s Attack matches 1.. store result entity @s damage double 1 run scoreboard players get @e[tag=Mob,limit=1,sort=nearest,distance=..3] Attack

--- a/data/entity/function/tick.mcfunction
+++ b/data/entity/function/tick.mcfunction
@@ -13,3 +13,4 @@ execute as @e[type=#entity:has_in_ground] run function entity:has_in_ground/chec
 
 ### エンティティPortalCooldownチェック
 execute as @e[tag=CooldownRequired,nbt={PortalCooldown:0}] at @s run function entity:cooldown
+execute as @e[type=#entity:has_in_ground,tag=CooldownRequired,tag=!Flying,nbt={life:1159s,inGround:true}] at @s run function entity:cooldown

--- a/data/entity/function/tick.mcfunction
+++ b/data/entity/function/tick.mcfunction
@@ -9,7 +9,7 @@ execute as @e[tag=!Initialized] at @s run function entity:initialize_entity
 kill @e[tag=OneTimeSpawner,nbt={SpawnData:{entity:{id:"tusb_mob:empty"}}}]
 
 # 飛翔状態の確認とタイマー移行
-execute as @e[type=#entity:has_in_ground] run function entity:has_in_ground/check
+execute as @e[type=#entity:has_in_ground] run function entity:has_in_ground/transfer_check
 
 ### エンティティPortalCooldownチェック
 execute as @e[tag=CooldownRequired,nbt={PortalCooldown:0}] at @s run function entity:cooldown

--- a/data/entity/function/tick.mcfunction
+++ b/data/entity/function/tick.mcfunction
@@ -8,5 +8,8 @@ execute as @e[tag=!Initialized] at @s run function entity:initialize_entity
 ### 召喚済み単回スポナー削除
 kill @e[tag=OneTimeSpawner,nbt={SpawnData:{entity:{id:"tusb_mob:empty"}}}]
 
+# 飛翔状態の確認とタイマー移行
+execute as @e[type=#entity:has_in_ground] run function entity:has_in_ground/check
+
 ### エンティティPortalCooldownチェック
 execute as @e[tag=CooldownRequired,nbt={PortalCooldown:0}] at @s run function entity:cooldown

--- a/data/entity/predicate/check_freeze.json
+++ b/data/entity/predicate/check_freeze.json
@@ -1,0 +1,38 @@
+{
+  "condition": "minecraft:any_of",
+  "terms": [
+    {
+      "condition": "entity_scores",
+      "entity": "this",
+      "scores": {
+        "ProjectileLife": {
+          "min": {
+            "type": "minecraft:score",
+            "target": {
+              "type": "minecraft:context",
+              "target": "this"
+            },
+            "score": "_"
+          },
+          "max": {
+            "type": "minecraft:score",
+            "target": {
+              "type": "minecraft:context",
+              "target": "this"
+            },
+            "score": "_"
+          }
+        }
+      }
+    },
+    {
+      "condition": "entity_scores",
+      "entity": "this",
+      "scores": {
+        "_": {
+          "max": 0
+        }
+      }
+    }
+  ]
+}

--- a/data/entity/predicate/has_in_ground/flying.json
+++ b/data/entity/predicate/has_in_ground/flying.json
@@ -1,0 +1,7 @@
+{
+  "condition": "minecraft:inverted",
+  "term": {
+    "condition": "minecraft:reference",
+    "name": "entity:has_in_ground/not_flying"
+  }
+}

--- a/data/entity/predicate/has_in_ground/not_flying.json
+++ b/data/entity/predicate/has_in_ground/not_flying.json
@@ -1,0 +1,10 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "type": "#entity:has_in_ground",
+    "movement": {
+      "speed": 0
+    }
+  }
+}

--- a/data/entity/tags/entity_type/has_in_ground.json
+++ b/data/entity/tags/entity_type/has_in_ground.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:arrow",
+    "minecraft:spectral_arrow",
+    "minecraft:trident"
+  ]
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-940
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
発生した問題はissueを参照してください。
inGroundを持つエンティティ = `arrow`, `spectral_arrow`, `trident` = `#entity:has_in_ground`が対象になります。

has_in_groundは`Flying`タグによって飛行状態を管理します。
* Flying かつ movement.speed = 0 :→ 着弾状態として`life`とGameTimeへタイマー機能を移行
* not Flying かつ movement.speed > 0 :→ 再飛行状態として`PortalCooldown`を着弾していたGameTime分引いてタイマー機能を移行

2種のタイマーを何度移行しあっても、最初に設定されたPortalCooldownの時間で必ず消滅します。
着弾後のlifeタイマーでもTickingRequiredで消滅します。

lifeは1200sまでで、1199sまで捕捉できます。しかし、TickingRequiredを考慮すると、時間切れの後1秒以内まで生存し続ける可能性があります。そのため、lifeの限界値を -2秒分した 1159sとします。
これにより、lifeタイマーで表現可能な時間は 33927ticks = 1697秒 = 29分 となります。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* tags/entity_typeの追加 : `#entity:has_in_ground`
* 飛行状態をチェックするpredicateの追加 : `entity:has_in_ground/**`
* 本機構の実装
	* 値変換の`get`/`set`の実装、状態確認の`check`
	* `entity:initialize_projectile`での初期化処理の追加
* CooldownRequiredへの対応
* TickingRequiredへの対応
	* 凍結条件を、(1秒前と同じCooldown OR Cooldownが0以下) へ変更
		PortalCooldownは0でカウントダウンがストップするが、lifeはカウントアップが止まることがないため

## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->

Initializeが済んだhas_in_groundへのPortalCooldown設定は今のところ実装されていないが、
`entity:has_in_ground/cooldown_set {PortalCooldown:100}`で指定できるように考えたい(今思いついた)

CooldownRequired以外でPortalCooldownのチェックがしたい要望もあるかもしれない(例: [nbt={PortalCooldown:0}])
if function に書ける `entity:has_in_ground/is_garbage`か、
`entity:has_in_ground/check_cooldown {PortalCooldown:40}`を追加するか

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
コマンドブロックで以下のコマンドをリピートすると各種の値が見やすいです。
```mcfunction
scoreboard players add @n[type=#entity:has_in_ground] Count 1
execute as @n[type=#entity:has_in_ground,scores={Count=0..}] run title @a actionbar ["[経過時間]:",{"score":{"name":"@s","objective":"Count"}},", [PortalCooldown]:",{"entity":"@s","nbt":"PortalCooldown"},", [life]:",{"entity":"@s","nbt":"life"}]
```

* タイマーの移行が正しくできていること
	弓矢を放つと200tickでCooldownが設定されるので、必ず200tickが経過した後1秒後にTickingRequiredによって削除されることを確認する。
* CooldownRequiredが着弾状態で正しく動くこと
	初期化処理をいじるとかして自分で付けてね
* CooldownRequiredが他のエンティティに対しては既存の動作をしていること
* TickingRequiredが着弾状態で正しく動くこと
	* 時間経過で消滅
	* 演算距離外に出た時に消滅
* TickingRequiredが他のエンティティに対しては既存の動作をしていること

## レビュー観点<!-- なかったらこの項目を削除してください -->
<!-- - 想定通りに動作するか？ -->
<!-- - 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ -->
tick処理を2つ増やしました。(飛行状態チェック, 着弾状態のCooldownRequried)
負荷とか大丈夫かな？気にしてくれると嬉しいです

## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->
現状のコードに、has_in_groundを対象にしてPortalCooldownを操作している処理は見つかりませんでした。

かなりコアな部分のレビューですがよろしくお願いします！！

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
