### PR TITLE
ルカナントラップの変更と1.21.4移植

### DIFF
--- a/data/enemy/function/damage/update_health.mcfunction
+++ b/data/enemy/function/damage/update_health.mcfunction
@@ -2,6 +2,10 @@
 #AbsorptionAmountの変化を取得
 execute store result score @s Damage run data get entity @s AbsorptionAmount -1
 scoreboard players add @s Damage 2048
+
+# ルカナン処理
+execute if entity @s[tag=Kasap] run function skill:act/hunter/kasap_trap/apply
+
 #AbsorptionAmountを2048に戻す
 data modify entity @s AbsorptionAmount set value 2048f
 # 累積ダメージ

--- a/data/enemy/function/tick.mcfunction
+++ b/data/enemy/function/tick.mcfunction
@@ -16,6 +16,10 @@ execute if entity @s[tag=EnemyBurn] run function effect:enemy_debuff/burn/tick
 execute if entity @s[tag=EnemyFreeze] unless predicate effect:freeze run function effect:enemy_debuff/freeze/cure
 execute if entity @s[tag=EnemyFreeze] positioned ~ ~-0.001 ~ if predicate effect:magma_block run function effect:enemy_debuff/freeze/cure
 
+## 狩人
+# ルカナントラップ
+execute if entity @s[scores={Kasap=1..}] run function skill:act/hunter/kasap_trap/enemy_tick
+
 # Mob Hitダメージ
 execute if entity @s[tag=HitDamageTaken] run function enemy:damage/hit
 

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -132,6 +132,8 @@ scoreboard objectives add WildCooking dummy {"text":"ワイルドクッキング
 scoreboard objectives add WildHealing dummy {"text":"ワイルドヒーリングレベル"}
 scoreboard objectives add EnergySave dummy {"text":"エナジーセーブ消費MP減少効果量"}
 scoreboard objectives add BlastSpark dummy {"text":"ブラストスパーク継続tick数"}
+scoreboard objectives add Kasap dummy {"text":"ルカナントラップ継続秒数"}
+scoreboard objectives add KasapRatio dummy {"text":"ルカナントラップダメージ倍率"}
 #白魔導士
 scoreboard objectives add HaloBound dummy {"text":"ヘイローバウンド演出カウント"}
 #黒魔導士

--- a/data/makeup/function/skill/act/hunter/kasap_trap/act0.mcfunction
+++ b/data/makeup/function/skill/act/hunter/kasap_trap/act0.mcfunction
@@ -1,0 +1,7 @@
+#> makeup:skill/act/hunter/kasap_trap/act0
+#
+# ルカナントラップ発動
+playsound minecraft:block.piston.extend player @a[distance=..16] ~ ~ ~ 1 1
+playsound minecraft:block.lever.click player @a[distance=..16] ~ ~ ~ 1 1
+playsound minecraft:block.conduit.deactivate player @a[distance=..16] ~ ~ ~ 1 1.5
+particle minecraft:end_rod ~ ~ ~ 0 0.5 0 0.3 30 force

--- a/data/makeup/function/skill/act/hunter/kasap_trap/tick.mcfunction
+++ b/data/makeup/function/skill/act/hunter/kasap_trap/tick.mcfunction
@@ -1,0 +1,5 @@
+#> makeup:skill/act/hunter/kasap_trap/tick
+#
+# ルカナントラップ毎tick発動
+particle minecraft:falling_dust{block_state:{Name:pink_wool}} ~ ~0.7 ~ 2.5 0 2.5 1 9 force @a[tag=ShowParticles]
+particle minecraft:dust{color:[0.61,0.15,0.13],scale:1} ~ ~0.5 ~ 2.5 2.5 2.5 1 6 force @a[tag=ShowParticles]

--- a/data/skill/function/act/hunter/kasap_trap/act0.mcfunction
+++ b/data/skill/function/act/hunter/kasap_trap/act0.mcfunction
@@ -1,0 +1,10 @@
+#> skill:act/hunter/kasap_trap/act0
+#
+# ルカナントラップ発動
+
+# 前方探索
+data modify storage calc: SearchForward set value {Loop:5,Stop:[Block]}
+execute anchored eyes positioned ^ ^ ^ anchored feet run function calc:geometry/search_forward/
+execute at 0-0-0-0-0 run function skill:act/hunter/kasap_trap/act1
+# 演出
+function makeup:skill/act/hunter/kasap_trap/act0

--- a/data/skill/function/act/hunter/kasap_trap/act1.mcfunction
+++ b/data/skill/function/act/hunter/kasap_trap/act1.mcfunction
@@ -1,0 +1,10 @@
+#> skill:act/hunter/kasap_trap/act1
+#
+# ルカナントラップ発動
+
+# AEC召喚
+# ReapplicationDelay: ダメージ増加倍率
+execute if score _ Level matches 1 run summon minecraft:area_effect_cloud ~ ~ ~ {Radius:0.01f,Particle:{type:angry_villager},ReapplicationDelay:125,Duration:300,Tags:[Skill,KasapTrap,NativeTask]}
+execute if score _ Level matches 2 run summon minecraft:area_effect_cloud ~ ~ ~ {Radius:0.01f,Particle:{type:angry_villager},ReapplicationDelay:150,Duration:300,Tags:[Skill,KasapTrap,NativeTask]}
+execute if score _ Level matches 3 run summon minecraft:area_effect_cloud ~ ~ ~ {Radius:0.01f,Particle:{type:angry_villager},ReapplicationDelay:175,Duration:300,Tags:[Skill,KasapTrap,NativeTask]}
+execute if score _ Level matches 4 run summon minecraft:area_effect_cloud ~ ~ ~ {Radius:0.01f,Particle:{type:angry_villager},ReapplicationDelay:200,Duration:300,Tags:[Skill,KasapTrap,NativeTask]}

--- a/data/skill/function/act/hunter/kasap_trap/apply.mcfunction
+++ b/data/skill/function/act/hunter/kasap_trap/apply.mcfunction
@@ -1,0 +1,10 @@
+#> skill:act/hunter/kasap_trap/apply
+#
+# ルカナン適用
+#
+# @within enemy:damage/update_health
+
+# DamageをKasapRatio/100倍
+scoreboard players set _ _ 100
+scoreboard players operation @s Damage *= @s KasapRatio
+scoreboard players operation @s Damage /= _ _

--- a/data/skill/function/act/hunter/kasap_trap/enemy_tick.mcfunction
+++ b/data/skill/function/act/hunter/kasap_trap/enemy_tick.mcfunction
@@ -1,0 +1,6 @@
+#> skill:act/hunter/kasap_trap/enemy_tick
+#
+# ルカナントラップ効果消費
+scoreboard players remove @s Kasap 1
+execute if score @s Kasap matches 1.. run return fail
+tag @s remove Kasap

--- a/data/skill/function/act/hunter/kasap_trap/tick.mcfunction
+++ b/data/skill/function/act/hunter/kasap_trap/tick.mcfunction
@@ -7,7 +7,7 @@ execute store result score @e[tag=Enemy,distance=..5] KasapRatio run data get en
 
 # タグ・スコア適用
 tag @e[tag=Enemy,distance=..5] add Kasap
-scoreboard players set @e[tag=Enemy,distance=..5] Kasap 300
+scoreboard players set @e[tag=Enemy,distance=..5] Kasap 100
 
 # 演出
 function makeup:skill/act/hunter/kasap_trap/tick

--- a/data/skill/function/act/hunter/kasap_trap/tick.mcfunction
+++ b/data/skill/function/act/hunter/kasap_trap/tick.mcfunction
@@ -1,0 +1,13 @@
+#> skill:act/hunter/kasap_trap/tick
+#
+# ルカナントラップ継続
+
+# ダメージ増加倍率を取得
+execute store result score @e[tag=Enemy,distance=..5] KasapRatio run data get entity @s ReapplicationDelay
+
+# タグ・スコア適用
+tag @e[tag=Enemy,distance=..5] add Kasap
+scoreboard players set @e[tag=Enemy,distance=..5] Kasap 300
+
+# 演出
+function makeup:skill/act/hunter/kasap_trap/tick

--- a/data/skill/function/native_tick.mcfunction
+++ b/data/skill/function/native_tick.mcfunction
@@ -23,6 +23,9 @@ execute if entity @s[tag=HyokaRyoranDisplay] run function skill:act/ninja/hyoka_
 # ステークスファイア
 execute if entity @s[tag=StakesFire] run function makeup:skill/act/hunter/stakes_fire/tick
 
+# ルカナントラップ
+execute if entity @s[tag=KasapTrap] run function skill:act/hunter/kasap_trap/tick
+
 ## 白魔導士
 # ヘイローバウンド
 execute if entity @s[tag=HaloBound] run function skill:act/white_mage/halo_bound/tick


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-939
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
ルカナントラップの仕様と演出を変更し、1.21.4に移植した。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
1. 演出を見直し、範囲をわかりやすくした。
2. トラップから離れた後も5秒間持続するようにした。
3. ダメージシステムの変更に伴い、ダメージ編集の起点を変更した。

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
1. トラップが消失した後も効果が持続することを確認した。
2. ダメージが正常に編集された。

## レビュー観点<!-- なかったらこの項目を削除してください -->
<!-- - 想定通りに動作するか？ -->
<!-- - 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ -->
1.演出は見やすく、負荷が少ないか？（他のトラップでも同じ変更予定です） 
2.離れた後も持続すること、時間に問題がないか？（ボミオスにも適用します）
3.ダメージの編集に問題はないか？

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
