### PR TITLE
反射削除処理の検知方式を向きからMotionへ変更

### DIFF
--- a/data/calc/function/throw_projectile/.mcfunction
+++ b/data/calc/function/throw_projectile/.mcfunction
@@ -5,5 +5,6 @@ execute in area:control_area facing 0.0 0.0 0.0 facing ^ ^ ^-1 run function calc
 data modify entity @s Motion set from entity 0-0-0-0-0 Pos
 #Rotationをスコアに保存 真上or真下のときは初回判定スキップ
 execute store result score __ _ run data get entity 0-0-0-0-0 Rotation[1] 10
-execute if score __ _ matches -899..898 store result score @s[type=arrow] ArrowRotation run data get entity 0-0-0-0-0 Rotation[0] -1
+execute if score __ _ matches -899..898 store result score @s[type=arrow] ArrowMotionX run data get entity 0-0-0-0-0 Pos[0] 1000
+execute if score __ _ matches -899..898 store result score @s[type=arrow] ArrowMotionZ run data get entity 0-0-0-0-0 Pos[2] 1000
 scoreboard players reset __ _

--- a/data/calc/function/throw_projectile/.mcfunction
+++ b/data/calc/function/throw_projectile/.mcfunction
@@ -5,6 +5,6 @@ execute in area:control_area facing 0.0 0.0 0.0 facing ^ ^ ^-1 run function calc
 data modify entity @s Motion set from entity 0-0-0-0-0 Pos
 #Rotationをスコアに保存 真上or真下のときは初回判定スキップ
 execute store result score __ _ run data get entity 0-0-0-0-0 Rotation[1] 10
-execute if score __ _ matches -899..898 store result score @s[type=arrow] ArrowMotionX run data get entity 0-0-0-0-0 Pos[0] 1000
-execute if score __ _ matches -899..898 store result score @s[type=arrow] ArrowMotionZ run data get entity 0-0-0-0-0 Pos[2] 1000
+execute if score __ _ matches -899..898 store result score @s[type=arrow] ArrowMotionX if predicate entity:arrow_reflection/motion_x
+execute if score __ _ matches -899..898 store result score @s[type=arrow] ArrowMotionZ if predicate entity:arrow_reflection/motion_z
 scoreboard players reset __ _

--- a/data/entity/function/arrow_reflection.mcfunction
+++ b/data/entity/function/arrow_reflection.mcfunction
@@ -3,10 +3,13 @@
 ### 矢の反射削除処理
 ##############################
 
-#1tick前のRotationと一致しなければ削除
-execute unless score @s ArrowRotation matches -2147483648.. store result score @s ArrowRotation run data get entity @s Rotation[0]
-scoreboard players operation _ ArrowRotation = @s ArrowRotation
-execute store result score @s ArrowRotation run data get entity @s Rotation[0]
+#1tick前のMotionと一致しなければ削除
+execute unless score @s ArrowMotionX matches -2147483648.. store result score @s ArrowMotionX run data get entity @s Motion[0] 1000
+execute unless score @s ArrowMotionZ matches -2147483648.. store result score @s ArrowMotionZ run data get entity @s Motion[2] 1000
+scoreboard players operation _ ArrowMotionX = @s ArrowMotionX
+scoreboard players operation _ ArrowMotionZ = @s ArrowMotionZ
+execute store result score @s ArrowMotionX run data get entity @s Motion[0] 1000
+execute store result score @s ArrowMotionZ run data get entity @s Motion[2] 1000
 
-execute unless score _ ArrowRotation = @s ArrowRotation run tag @s add Garbage
-execute unless score _ ArrowRotation = @s[tag=HasSkillDisplay] ArrowRotation on passengers run kill @s[tag=SkillDisplay]
+execute if predicate entity:arrow_reflection run tag @s add Garbage
+execute if predicate entity:arrow_reflection if entity @s[tag=HasSkillDisplay] on passengers run kill @s[tag=SkillDisplay]

--- a/data/entity/function/arrow_reflection.mcfunction
+++ b/data/entity/function/arrow_reflection.mcfunction
@@ -4,12 +4,13 @@
 ##############################
 
 #1tick前のMotionと一致しなければ削除
-execute unless score @s ArrowMotionX matches -2147483648.. store result score @s ArrowMotionX run data get entity @s Motion[0] 1000
-execute unless score @s ArrowMotionZ matches -2147483648.. store result score @s ArrowMotionZ run data get entity @s Motion[2] 1000
+execute unless score @s ArrowMotionX matches -2147483648.. store result score @s ArrowMotionX if predicate entity:arrow_reflection/motion_x
+execute unless score @s ArrowMotionZ matches -2147483648.. store result score @s ArrowMotionZ if predicate entity:arrow_reflection/motion_z
 scoreboard players operation _ ArrowMotionX = @s ArrowMotionX
 scoreboard players operation _ ArrowMotionZ = @s ArrowMotionZ
-execute store result score @s ArrowMotionX run data get entity @s Motion[0] 1000
-execute store result score @s ArrowMotionZ run data get entity @s Motion[2] 1000
+execute store result score @s ArrowMotionX if predicate entity:arrow_reflection/motion_x
+execute store result score @s ArrowMotionZ if predicate entity:arrow_reflection/motion_z
 
-execute if predicate entity:arrow_reflection run tag @s add Garbage
-execute if predicate entity:arrow_reflection if entity @s[tag=HasSkillDisplay] on passengers run kill @s[tag=SkillDisplay]
+# ArrowMotion = 1 : +方向, 0 : -方向
+execute if predicate entity:arrow_reflection/ run tag @s add Garbage
+execute if predicate entity:arrow_reflection/ if entity @s[tag=HasSkillDisplay] on passengers run kill @s[tag=SkillDisplay]

--- a/data/entity/predicate/arrow_reflection.json
+++ b/data/entity/predicate/arrow_reflection.json
@@ -1,0 +1,139 @@
+{
+  "condition": "minecraft:all_of",
+  "terms": [
+    {
+      "condition": "minecraft:inverted",
+      "term": {
+        "condition": "minecraft:entity_properties",
+        "entity": "this",
+        "predicate": {
+          "movement": {
+            "speed": 0
+          }
+        }
+      }
+    },
+    {
+      "condition": "minecraft:any_of",
+      "terms": [
+        {
+          "condition": "minecraft:all_of",
+          "terms": [
+            {
+              "condition": "minecraft:value_check",
+              "value": {
+                "type": "minecraft:score",
+                "target": {
+                  "type": "fixed",
+                  "name": "_"
+                },
+                "score": "ArrowMotionX"
+              },
+              "range": {
+                "min": 0
+              }
+            },
+            {
+              "condition": "minecraft:entity_scores",
+              "entity": "this",
+              "scores": {
+                "ArrowMotionX": {
+                  "max": 0
+                }
+              }
+            }
+          ]
+        },
+        {
+          "condition": "minecraft:all_of",
+          "terms": [
+            {
+              "condition": "minecraft:value_check",
+              "value": {
+                "type": "minecraft:score",
+                "target": {
+                  "type": "fixed",
+                  "name": "_"
+                },
+                "score": "ArrowMotionX"
+              },
+              "range": {
+                "max": 0
+              }
+            },
+            {
+              "condition": "minecraft:entity_scores",
+              "entity": "this",
+              "scores": {
+                "ArrowMotionX": {
+                  "min": 0
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "condition": "minecraft:any_of",
+      "terms": [
+        {
+          "condition": "minecraft:all_of",
+          "terms": [
+            {
+              "condition": "minecraft:value_check",
+              "value": {
+                "type": "minecraft:score",
+                "target": {
+                  "type": "fixed",
+                  "name": "_"
+                },
+                "score": "ArrowMotionZ"
+              },
+              "range": {
+                "min": 0
+              }
+            },
+            {
+              "condition": "minecraft:entity_scores",
+              "entity": "this",
+              "scores": {
+                "ArrowMotionZ": {
+                  "max": 0
+                }
+              }
+            }
+          ]
+        },
+        {
+          "condition": "minecraft:all_of",
+          "terms": [
+            {
+              "condition": "minecraft:value_check",
+              "value": {
+                "type": "minecraft:score",
+                "target": {
+                  "type": "fixed",
+                  "name": "_"
+                },
+                "score": "ArrowMotionZ"
+              },
+              "range": {
+                "max": 0
+              }
+            },
+            {
+              "condition": "minecraft:entity_scores",
+              "entity": "this",
+              "scores": {
+                "ArrowMotionZ": {
+                  "min": 0
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/entity/predicate/arrow_reflection/.json
+++ b/data/entity/predicate/arrow_reflection/.json
@@ -29,16 +29,16 @@
                 },
                 "score": "ArrowMotionX"
               },
-              "range": {
-                "min": 0
-              }
+              "range": 1
             },
             {
-              "condition": "minecraft:entity_scores",
+              "condition": "minecraft:entity_properties",
               "entity": "this",
-              "scores": {
-                "ArrowMotionX": {
-                  "max": 0
+              "predicate": {
+                "movement": {
+                  "x": {
+                    "max": 0
+                  }
                 }
               }
             }
@@ -57,16 +57,16 @@
                 },
                 "score": "ArrowMotionX"
               },
-              "range": {
-                "max": 0
-              }
+              "range": 0
             },
             {
-              "condition": "minecraft:entity_scores",
+              "condition": "minecraft:entity_properties",
               "entity": "this",
-              "scores": {
-                "ArrowMotionX": {
-                  "min": 0
+              "predicate": {
+                "movement": {
+                  "x": {
+                    "min": 0
+                  }
                 }
               }
             }
@@ -90,16 +90,16 @@
                 },
                 "score": "ArrowMotionZ"
               },
-              "range": {
-                "min": 0
-              }
+              "range": 1
             },
             {
-              "condition": "minecraft:entity_scores",
+              "condition": "minecraft:entity_properties",
               "entity": "this",
-              "scores": {
-                "ArrowMotionZ": {
-                  "max": 0
+              "predicate": {
+                "movement": {
+                  "z": {
+                    "max": 0
+                  }
                 }
               }
             }
@@ -118,16 +118,16 @@
                 },
                 "score": "ArrowMotionZ"
               },
-              "range": {
-                "max": 0
-              }
+              "range": 0
             },
             {
-              "condition": "minecraft:entity_scores",
+              "condition": "minecraft:entity_properties",
               "entity": "this",
-              "scores": {
-                "ArrowMotionZ": {
-                  "min": 0
+              "predicate": {
+                "movement": {
+                  "z": {
+                    "min": 0
+                  }
                 }
               }
             }

--- a/data/entity/predicate/arrow_reflection/motion_x.json
+++ b/data/entity/predicate/arrow_reflection/motion_x.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "movement": {
+      "x": {
+        "min": 0
+      }
+    }
+  }
+}

--- a/data/entity/predicate/arrow_reflection/motion_z.json
+++ b/data/entity/predicate/arrow_reflection/motion_z.json
@@ -1,0 +1,11 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "movement": {
+      "z": {
+        "min": 0
+      }
+    }
+  }
+}

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -77,7 +77,6 @@ scoreboard objectives add ShieldUsingTick dummy {"text":"盾を使用したtick"
 scoreboard objectives add Calc dummy {"text": "計算用"}
 scoreboard objectives add Random dummy {"text": "乱数用"}
 scoreboard objectives add TitleOffset dummy {"text":"タイトル表示オフセット"}
-scoreboard objectives add ArrowRotation dummy {"text":"矢の向き"}
 scoreboard objectives add ArrowMotionX dummy {"text":"矢の速度 X"}
 scoreboard objectives add ArrowMotionZ dummy {"text":"矢の速度 Z"}
 scoreboard objectives add ProjectileLife dummy {"text":"飛翔物生存時間"}

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -78,6 +78,8 @@ scoreboard objectives add Calc dummy {"text": "計算用"}
 scoreboard objectives add Random dummy {"text": "乱数用"}
 scoreboard objectives add TitleOffset dummy {"text":"タイトル表示オフセット"}
 scoreboard objectives add ArrowRotation dummy {"text":"矢の向き"}
+scoreboard objectives add ArrowMotionX dummy {"text":"矢の速度 X"}
+scoreboard objectives add ArrowMotionZ dummy {"text":"矢の速度 Z"}
 scoreboard objectives add ProjectileLife dummy {"text":"飛翔物生存時間"}
 
 ###ジョブ系


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-945
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
問題はissueを確認してください

反射削除処理を`Rotation[0]`から、`Motion[0]`と`Motion[2]`の比較へ変更した。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* `ArrowRotation`を削除
* `ArrowMotionX`,`ArrowMotionZ`を追加
* 反射削除の条件を変更
	* movement.speedが0ではない AND (X軸について進行方向が反転した) AND (Z軸について進行方向が判定した)
* `calc:throw_projectile/` の保存情報を変更

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
issueにある再現コマンドの矢を使用して、ちゃんと飛ぶこと、無敵のMobに当たったときに削除されること。
## レビュー観点<!-- なかったらこの項目を削除してください -->
<!-- - 想定通りに動作するか？ -->
<!-- - 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ -->
NBT読み取りを2種に増やしましたが、どちらかの軸のみにできれば、前と同じになるんですよね。
ただ、軸の境界値付近で偏差によって方向の正負が変わったら誤検知を起こしそうなんですよね……

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
