### PR TITLE
エナジーセーブの1.21.4移植

### DIFF
--- a/data/makeup/function/skill/act/hunter/energy_save/apply.mcfunction
+++ b/data/makeup/function/skill/act/hunter/energy_save/apply.mcfunction
@@ -1,0 +1,5 @@
+
+playsound minecraft:block.brewing_stand.brew master @a[distance=..16] ~ ~ ~ 1 0
+playsound minecraft:block.brewing_stand.brew master @a[distance=..16] ~ ~ ~ 1 0.5
+playsound minecraft:entity.cat.ambient master @a[distance=..16] ~ ~ ~ 0.5 1.5
+summon minecraft:area_effect_cloud ~ ~ ~ {Particle:"minecraft:entity_effect",Radius:3f,Duration:15,Color:2752382}

--- a/data/makeup/function/skill/act/hunter/energy_save/apply.mcfunction
+++ b/data/makeup/function/skill/act/hunter/energy_save/apply.mcfunction
@@ -1,5 +1,8 @@
+#> makeup:skill/act/hunter/energy_save/apply
+#
+# エナジーセーブ発動
 
-playsound minecraft:block.brewing_stand.brew master @a[distance=..16] ~ ~ ~ 1 0
-playsound minecraft:block.brewing_stand.brew master @a[distance=..16] ~ ~ ~ 1 0.5
-playsound minecraft:entity.cat.ambient master @a[distance=..16] ~ ~ ~ 0.5 1.5
-summon minecraft:area_effect_cloud ~ ~ ~ {Particle:"minecraft:entity_effect",Radius:3f,Duration:15,Color:2752382}
+playsound minecraft:block.brewing_stand.brew player @a[distance=..16] ~ ~ ~ 1 0
+playsound minecraft:block.brewing_stand.brew player @a[distance=..16] ~ ~ ~ 1 0.5
+playsound minecraft:entity.cat.ambient player @a[distance=..16] ~ ~ ~ 0.5 1.5
+summon minecraft:area_effect_cloud ~ ~ ~ {Particle:{type:"minecraft:entity_effect",color:-14024833},Radius:3f,Duration:15}

--- a/data/skill/function/act/hunter/energy_save/act0.mcfunction
+++ b/data/skill/function/act/hunter/energy_save/act0.mcfunction
@@ -1,0 +1,9 @@
+
+### エナジーセーブ発動
+
+execute unless score @s SneakTime matches 1.. as @s run function skill:act/hunter/energy_save/apply
+execute if score @s SneakTime matches 1.. as @a[distance=..15] run function skill:act/hunter/energy_save/apply
+
+###メッセージ
+execute unless score @s SneakTime matches 1.. run tellraw @a [{"translate":"%1$sに%2$sの効果！","color":"green","with":[{"selector":"@s"},{"translate":"エナジーセーブ","color":"white","hoverEvent":{"action":"show_text","value":{"translate":"自身の次に使うスキルの消費MPを減少する。","color":"white"}}}]}]
+execute if score @s SneakTime matches 1.. run tellraw @a [{"translate":"%1$sに%2$sの効果！","color":"green","with":[{"selector":"@a[distance=..15]"},{"translate":"エナジーセーブ","color":"white","hoverEvent":{"action":"show_text","value":{"translate":"自身の次に使うスキルの消費MPを減少する。","color":"white"}}}]}]

--- a/data/skill/function/act/hunter/energy_save/act0.mcfunction
+++ b/data/skill/function/act/hunter/energy_save/act0.mcfunction
@@ -1,9 +1,10 @@
-
-### エナジーセーブ発動
+#> skill:act/hunter/energy_save/act0
+#
+# エナジーセーブ発動
 
 execute unless score @s SneakTime matches 1.. as @s run function skill:act/hunter/energy_save/apply
 execute if score @s SneakTime matches 1.. as @a[distance=..15] run function skill:act/hunter/energy_save/apply
 
-###メッセージ
+# メッセージ
 execute unless score @s SneakTime matches 1.. run tellraw @a [{"translate":"%1$sに%2$sの効果！","color":"green","with":[{"selector":"@s"},{"translate":"エナジーセーブ","color":"white","hoverEvent":{"action":"show_text","value":{"translate":"自身の次に使うスキルの消費MPを減少する。","color":"white"}}}]}]
 execute if score @s SneakTime matches 1.. run tellraw @a [{"translate":"%1$sに%2$sの効果！","color":"green","with":[{"selector":"@a[distance=..15]"},{"translate":"エナジーセーブ","color":"white","hoverEvent":{"action":"show_text","value":{"translate":"自身の次に使うスキルの消費MPを減少する。","color":"white"}}}]}]

--- a/data/skill/function/act/hunter/energy_save/apply.mcfunction
+++ b/data/skill/function/act/hunter/energy_save/apply.mcfunction
@@ -1,0 +1,9 @@
+
+### エナジーセーブ適用
+
+execute if score _ Level matches 1 run scoreboard players set _ _ 1
+execute if score _ Level matches 2 run scoreboard players set _ _ 2
+execute if score _ Level matches 3 run scoreboard players set _ _ 3
+scoreboard players operation @s EnergySave > _ _
+
+function makeup:skill/act/hunter/energy_save/apply

--- a/data/skill/function/act/hunter/energy_save/apply.mcfunction
+++ b/data/skill/function/act/hunter/energy_save/apply.mcfunction
@@ -1,9 +1,11 @@
-
-### エナジーセーブ適用
+#> skill:act/hunter/energy_save/apply
+#
+# エナジーセーブ適用
 
 execute if score _ Level matches 1 run scoreboard players set _ _ 1
 execute if score _ Level matches 2 run scoreboard players set _ _ 2
 execute if score _ Level matches 3 run scoreboard players set _ _ 3
 scoreboard players operation @s EnergySave > _ _
 
+# 演出
 function makeup:skill/act/hunter/energy_save/apply

--- a/data/skill/function/act/hunter/energy_save/calc.mcfunction
+++ b/data/skill/function/act/hunter/energy_save/calc.mcfunction
@@ -1,0 +1,13 @@
+
+### エナジーセーブ効果適用
+
+scoreboard players set _ Calc 4
+scoreboard players operation _ EnergySave = _ Calc
+scoreboard players operation _ EnergySave -= @s EnergySave
+scoreboard players operation _ MP *= _ EnergySave
+scoreboard players operation _ MP /= _ Calc
+
+scoreboard players remove @s EnergySave 1
+execute if score @s EnergySave matches ..0 run tellraw @a [{"translate":"%1$sの%2$sの効果が切れた。","color":"yellow","with":[{"selector":"@s"},{"translate":"エナジーセーブ","color":"white","hoverEvent":{"action":"show_text","value":{"translate":"自身の次に使うスキルの消費MPを減少する。","color":"white"}}}]}]
+
+scoreboard players reset @s[scores={EnergySave=..0}] EnergySave

--- a/data/skill/function/act/hunter/energy_save/calc.mcfunction
+++ b/data/skill/function/act/hunter/energy_save/calc.mcfunction
@@ -1,5 +1,6 @@
-
-### エナジーセーブ効果適用
+#> skill:act/hunter/energy_save/calc
+#
+# エナジーセーブ効果適用
 
 scoreboard players set _ Calc 4
 scoreboard players operation _ EnergySave = _ Calc


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL
GH-947

## 対応内容・対応背景・妥協点
エナジーセーブを1.21.4に移植した

## やったこと
サウンドソースの変更
演出のエリアエフェクトクラウドの透明度を0%に

## テスト
発動後、次のスキルがのMP消費量が下がるのを確認

## レビュー観点
他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
