### PR TITLE
nbt引数のAbsorptionAmountの値を修正

### DIFF
--- a/data/player/function/trigger/projectile/skill.mcfunction
+++ b/data/player/function/trigger/projectile/skill.mcfunction
@@ -1,7 +1,7 @@
 #> player:trigger/projectile/skill
 #狩人
 execute if entity @s[tag=ChainArrow] run function skill:act/hunter/chain_arrow/hit
-execute if entity @s[tag=StakesSucceeded] as @e[tag=Enemy,nbt=!{AbsorptionAmount:1000000f},distance=0] run function skill:act/hunter/stakes_fire/hit
+execute if entity @s[tag=StakesSucceeded] as @e[tag=Enemy,nbt=!{AbsorptionAmount:2048f},distance=0] run function skill:act/hunter/stakes_fire/hit
 execute if entity @s[tag=BlastSpark] run function skill:act/hunter/blast_spark/hit
 #忍者
 execute if entity @s[tag=Shuriken] run function makeup:skill/act/ninja/shuriken/hit
@@ -12,4 +12,4 @@ execute if entity @s[tag=ShiningBolt] run function makeup:skill/act/white_mage/s
 #黒魔導士
 execute if entity @s[tag=WindWallTornado] run function makeup:skill/act/black_mage/wind_wall/hit
 #共通
-execute if entity @s[tag=WeakPaint] at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:1000000f},distance=0] unless score @s Weakness matches 1.. run function skill:act/common/weakness_paint/hit
+execute if entity @s[tag=WeakPaint] at 0-0-0-0-2 as @e[tag=Enemy,nbt=!{AbsorptionAmount:2048f},distance=0] unless score @s Weakness matches 1.. run function skill:act/common/weakness_paint/hit


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
NO-ISSUE
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
セレクター引数のnbt引数で、AbsorptionAmountをチェックするときに1000000fのままのものがあった。
`function`移行済みのもののみ確認

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* nbt引数のAbsorptionAmountの値を2048fへ修正

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
