### PR TITLE
CallCondition "function"が必ず失敗するバグの修正

### DIFF
--- a/data/ai/function/call/condition/condition/function.mcfunction
+++ b/data/ai/function/call/condition/condition/function.mcfunction
@@ -6,5 +6,6 @@ data modify storage mob_data: Tags set from entity @s Tags
 data modify entity @s Tags set from storage mob_data: Condition.Tags
 #function呼び出し
 execute store success score _ Calc run function #entity:spawn_data
+execute if score _ Calc matches 2.. run scoreboard players set _ Calc 1
 #Tagsを復元
 data modify entity @s Tags set from storage mob_data: Tags


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-952
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
CallConditionの"function"は、条件実行ファイルの最後のコマンドの成功結果を store success していたが、returnコマンドでないと目的の呼び出しまで結果が返らなくなっていた。
また、tags/functionの`#entity:spawn_data`からの呼び出しで、複数のコマンドの成功結果が返ってきたときに`_ Calc`が2以上になってしまう可能性を考えて、1に丸めることにした
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* <ツールの更新> 各分岐functionの中のfunctionコマンドをreturn runで実行するように変更
* <シートの変更> おそらくCallCondition "function"で呼び出されるであろうfunctionの最後のコマンドにreturn runを追加
* `_ Calc`に返ってきた結果が2以上だった時に1に丸める処理を追加

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
私は、アサガストで検証しました

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
