### PR TITLE
ニフラムトラップの変更と1.21.4移植

### DIFF
--- a/data/makeup/function/skill/act/hunter/expel_trap/act0.mcfunction
+++ b/data/makeup/function/skill/act/hunter/expel_trap/act0.mcfunction
@@ -1,0 +1,7 @@
+#> makeup:skill/act/hunter/expel_trap/act0
+#
+# ニフラムトラップ発動演出
+playsound minecraft:block.piston.extend player @a[distance=..16] ~ ~ ~ 1 1
+playsound minecraft:block.lever.click player @a[distance=..16] ~ ~ ~ 1 1
+playsound minecraft:entity.evoker.prepare_summon player @a[distance=..16] ~ ~ ~ 1 2
+particle minecraft:end_rod ~ ~ ~ 0 0.5 0 0.3 30 force

--- a/data/makeup/function/skill/act/hunter/expel_trap/apply.mcfunction
+++ b/data/makeup/function/skill/act/hunter/expel_trap/apply.mcfunction
@@ -1,0 +1,7 @@
+#> makeup:skill/act/hunter/expel_trap/apply
+#
+# ニフラムトラップ適用演出
+playsound minecraft:entity.axolotl.death player @a[distance=..16] ~ ~ ~ 1 1
+playsound minecraft:block.beacon.deactivate player @a[distance=..16] ~ ~ ~ 0.5 2
+particle minecraft:wax_on ~ ~1 ~ 0.2 0.2 0.2 10 30 force
+particle minecraft:witch ~ ~ ~ 0.4 0.4 0.4 1 30 force

--- a/data/makeup/function/skill/act/hunter/expel_trap/tick.mcfunction
+++ b/data/makeup/function/skill/act/hunter/expel_trap/tick.mcfunction
@@ -1,0 +1,5 @@
+#> makeup:skill/act/hunter/expel_trap/tick
+#
+# ニフラムトラップ毎tick演出
+particle minecraft:falling_dust{block_state:{Name:yellow_wool}} ~ ~0.7 ~ 2.5 0 2.5 1 9 force @a[tag=ShowParticles]
+particle minecraft:dust{color:[0.44,0.14,0.62],scale:1} ~ ~0.5 ~ 2.5 2.5 2.5 1 6 force @a[tag=ShowParticles]

--- a/data/skill/function/act/hunter/expel_trap/act0.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/act0.mcfunction
@@ -1,0 +1,11 @@
+#> skill:act/hunter/expel_trap/act0
+#
+# ニフラムトラップ発動
+
+# 前方を探索
+data modify storage calc: SearchForward set value {Loop:5,Stop:[Block]}
+execute anchored eyes positioned ^ ^ ^ anchored feet run function calc:geometry/search_forward/
+execute at 0-0-0-0-0 run function skill:act/hunter/expel_trap/act1
+
+# 演出
+function makeup:skill/act/hunter/expel_trap/act0

--- a/data/skill/function/act/hunter/expel_trap/act1.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/act1.mcfunction
@@ -6,8 +6,7 @@
 summon minecraft:area_effect_cloud ~ ~ ~ {Radius:0.01f,Particle:{type:angry_villager},Duration:300,Tags:[Skill,ExpelTrap,NativeTask]}
 
 # プレイヤーレベル取得
-execute store result score _ Calc run scoreboard players get @s Level
-
+scoreboard players operation _ Calc = @s Level
 # 計算結果以下のレベルの敵は消滅する
 # スキルレベル1 : 20 + Level / 4
 # スキルレベル2 : 20 + Level / 3
@@ -16,9 +15,8 @@ scoreboard players operation _ _ -= _ Level
 scoreboard players operation _ Calc /= _ _
 scoreboard players set _ _ 20
 scoreboard players operation _ Calc += _ _
-
 # 計算結果を保存
-execute store result score @e[tag=ExpelTrap,tag=!Initialized,distance=0,limit=1] Level run scoreboard players get _ Calc
+scoreboard players operation @e[tag=ExpelTrap,tag=!Initialized,distance=0,limit=1] Level = _ Calc
 
 # 演出
 function makeup:skill/act/hunter/expel_trap/act0

--- a/data/skill/function/act/hunter/expel_trap/act1.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/act1.mcfunction
@@ -1,0 +1,25 @@
+#> skill:act/hunter/expel_trap/act1
+#
+# ニフラムトラップ発動
+
+# AEC召喚
+summon minecraft:area_effect_cloud ~ ~ ~ {Radius:0.01f,Particle:{type:angry_villager},Duration:300,Tags:[Skill,ExpelTrap,NativeTask]}
+
+# プレイヤーレベル取得
+execute store result score _ Calc run scoreboard players get @s Level
+
+# 計算結果以下のレベルの敵は消滅する
+# スキルレベル1 : 20 + Level / 4
+# スキルレベル2 : 20 + Level / 3
+scoreboard players set _ _ 5
+scoreboard players operation _ _ -= _ Level
+scoreboard players operation _ Calc /= _ _
+scoreboard players set _ _ 20
+scoreboard players operation _ Calc += _ _
+tellraw @a [{"score":{"name":"_","objective":"Calc"}}]
+
+# 計算結果を保存
+execute store result entity @e[tag=ExpelTrap,tag=!Initialized,distance=0,limit=1] RadiusOnUse float 1 run scoreboard players get _ Calc
+
+# 演出
+function makeup:skill/act/hunter/expel_trap/act0

--- a/data/skill/function/act/hunter/expel_trap/act1.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/act1.mcfunction
@@ -18,7 +18,7 @@ scoreboard players set _ _ 20
 scoreboard players operation _ Calc += _ _
 
 # 計算結果を保存
-execute store result entity @e[tag=ExpelTrap,tag=!Initialized,distance=0,limit=1] RadiusOnUse float 1 run scoreboard players get _ Calc
+execute store result score @e[tag=ExpelTrap,tag=!Initialized,distance=0,limit=1] Level run scoreboard players get _ Calc
 
 # 演出
 function makeup:skill/act/hunter/expel_trap/act0

--- a/data/skill/function/act/hunter/expel_trap/act1.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/act1.mcfunction
@@ -16,7 +16,6 @@ scoreboard players operation _ _ -= _ Level
 scoreboard players operation _ Calc /= _ _
 scoreboard players set _ _ 20
 scoreboard players operation _ Calc += _ _
-tellraw @a [{"score":{"name":"_","objective":"Calc"}}]
 
 # 計算結果を保存
 execute store result entity @e[tag=ExpelTrap,tag=!Initialized,distance=0,limit=1] RadiusOnUse float 1 run scoreboard players get _ Calc

--- a/data/skill/function/act/hunter/expel_trap/apply.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/apply.mcfunction
@@ -1,0 +1,9 @@
+#> skill:act/hunter/expel_trap/apply
+#
+# ニフラムトラップ適用
+
+# kill
+tag @s add Garbage
+
+# 演出
+function makeup:skill/act/hunter/expel_trap/apply

--- a/data/skill/function/act/hunter/expel_trap/tick.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/tick.mcfunction
@@ -1,0 +1,12 @@
+#> skill:act/hunter/expel_trap/tick
+#
+# ニフラムトラップ毎tick処理
+
+# 計算結果を取得
+execute store result score _ Calc run data get entity @s RadiusOnUse
+
+# レベルが計算結果以下の敵を消滅
+execute as @e[tag=Enemy,distance=..5] unless score _ Calc < @s Level positioned as @s run function skill:act/hunter/expel_trap/apply
+
+# 演出
+function makeup:skill/act/hunter/expel_trap/tick

--- a/data/skill/function/act/hunter/expel_trap/tick.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/tick.mcfunction
@@ -3,7 +3,7 @@
 # ニフラムトラップ毎tick処理
 
 # 計算結果を取得
-execute store result score _ Calc run data get entity @s RadiusOnUse
+execute store result score _ Calc run scoreboard players get @s Level
 
 # レベルが計算結果以下の敵を消滅
 execute as @e[tag=Enemy,distance=..5] unless score _ Calc < @s Level positioned as @s run function skill:act/hunter/expel_trap/apply

--- a/data/skill/function/act/hunter/expel_trap/tick.mcfunction
+++ b/data/skill/function/act/hunter/expel_trap/tick.mcfunction
@@ -3,7 +3,7 @@
 # ニフラムトラップ毎tick処理
 
 # 計算結果を取得
-execute store result score _ Calc run scoreboard players get @s Level
+scoreboard players operation _ Calc = @s Level
 
 # レベルが計算結果以下の敵を消滅
 execute as @e[tag=Enemy,distance=..5] unless score _ Calc < @s Level positioned as @s run function skill:act/hunter/expel_trap/apply

--- a/data/skill/function/native_tick.mcfunction
+++ b/data/skill/function/native_tick.mcfunction
@@ -31,3 +31,7 @@ execute if entity @s[tag=KasapTrap] run function skill:act/hunter/kasap_trap/tic
 ## 白魔導士
 # ヘイローバウンド
 execute if entity @s[tag=HaloBound] run function skill:act/white_mage/halo_bound/tick
+
+## トラップ
+# ニフラムトラップ
+execute if entity @s[tag=ExpelTrap] run function skill:act/hunter/expel_trap/tick


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-970
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
ニフラムトラップを変更して1.21.4に移植した。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
・サウンドソースの変更
・演出をルカナントラップと同じように変更
・レベルの保存方法を変更
## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
トラップの実行順が元々後ろにあるが、現在は狩人スキルと同じ場所にある。ボミオスがマージされ次第コンフリクトと共に修正する予定。

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
