### PR TITLE
プレイヤーデバフ:復活酔いの追加

### DIFF
--- a/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
+++ b/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
@@ -7,7 +7,8 @@ scoreboard players set _ _ 1
 scoreboard players set _ Calc 2
 execute if score @s RevivalSicknessTimer matches 1.. run scoreboard players operation _ _ *= _ Calc
 
-# 持続時間を設定 難易度で効果時間が変化（ピクニック:2s、カジュアル:4s、エキスパート:8s）
+# 持続時間を設定 難易度で効果時間が変化（デバッグ:0s、ピクニック:2s、カジュアル:4s、エキスパート:8s）
+execute if data storage main: difficult{world:"debug"} run scoreboard players set @s RevivalSicknessTimer 0
 execute if data storage main: difficult{world:"picnic"} run scoreboard players set @s RevivalSicknessTimer 2
 execute if data storage main: difficult{world:"casual"} run scoreboard players set @s RevivalSicknessTimer 4
 execute if data storage main: difficult{world:"expert"} run scoreboard players set @s RevivalSicknessTimer 8

--- a/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
+++ b/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
@@ -1,0 +1,22 @@
+#> effect:player_debuff/revival_sickness/apply
+#
+# 復活酔い追加処理
+
+# 効果中なら効果時間2倍
+scoreboard players set _ _ 1
+scoreboard players set _ Calc 2
+execute if score @s RevivalSicknessTimer matches 1.. run scoreboard players operation _ _ *= _ Calc
+
+# 持続時間を設定 難易度で効果時間が変化（ピクニック:2s、カジュアル:4s、エキスパート:8s）
+execute if data storage main: difficult{world:"picnic"} run scoreboard players set @s RevivalSicknessTimer 2
+execute if data storage main: difficult{world:"casual"} run scoreboard players set @s RevivalSicknessTimer 4
+execute if data storage main: difficult{world:"expert"} run scoreboard players set @s RevivalSicknessTimer 8
+
+# マルチなら効果時間2倍
+execute if entity @a[distance=0.01..] run scoreboard players operation _ _ *= _ Calc
+
+# 倍率を掛ける
+scoreboard players operation @s RevivalSicknessTimer *= _ _
+
+# 演出
+function makeup:effect/player_debuff/revival_sickness/apply

--- a/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
+++ b/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
@@ -13,7 +13,8 @@ execute if data storage main: difficult{world:"casual"} run scoreboard players s
 execute if data storage main: difficult{world:"expert"} run scoreboard players set @s RevivalSicknessTimer 8
 
 # マルチなら効果時間2倍
-execute if entity @a[distance=0.01..] run scoreboard players operation _ _ *= _ Calc
+execute store result score @s _ if entity @a
+execute if score @s _ matches 2.. run scoreboard players operation _ _ *= _ Calc
 
 # 倍率を掛ける
 scoreboard players operation @s RevivalSicknessTimer *= _ _

--- a/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
+++ b/data/effect/function/player_debuff/revival_sickness/apply.mcfunction
@@ -4,8 +4,7 @@
 
 # 効果中なら効果時間2倍
 scoreboard players set _ _ 1
-scoreboard players set _ Calc 2
-execute if score @s RevivalSicknessTimer matches 1.. run scoreboard players operation _ _ *= _ Calc
+execute if score @s RevivalSicknessTimer matches 1.. run scoreboard players operation _ _ += _ _
 
 # 持続時間を設定 難易度で効果時間が変化（デバッグ:0s、ピクニック:2s、カジュアル:4s、エキスパート:8s）
 execute if data storage main: difficult{world:"debug"} run scoreboard players set @s RevivalSicknessTimer 0
@@ -15,7 +14,7 @@ execute if data storage main: difficult{world:"expert"} run scoreboard players s
 
 # マルチなら効果時間2倍
 execute store result score @s _ if entity @a
-execute if score @s _ matches 2.. run scoreboard players operation _ _ *= _ Calc
+execute if score @s _ matches 2.. run scoreboard players operation _ _ += _ _
 
 # 倍率を掛ける
 scoreboard players operation @s RevivalSicknessTimer *= _ _

--- a/data/effect/function/player_debuff/revival_sickness/cure.mcfunction
+++ b/data/effect/function/player_debuff/revival_sickness/cure.mcfunction
@@ -1,0 +1,8 @@
+#> effect:player_debuff/revival_sickness/cure
+#
+# 復活酔い解除処理
+scoreboard players reset @s RevivalSicknessTimer
+effect clear @s mining_fatigue
+
+# 演出
+function makeup:effect/player_debuff/revival_sickness/cure

--- a/data/effect/function/player_debuff/revival_sickness/second.mcfunction
+++ b/data/effect/function/player_debuff/revival_sickness/second.mcfunction
@@ -1,0 +1,8 @@
+#> effect:player_debuff/revival_sickness/second
+#
+# 復活酔い毎秒処理
+scoreboard players remove @s RevivalSicknessTimer 1
+execute if score @s RevivalSicknessTimer matches 0 run return run function effect:player_debuff/revival_sickness/cure
+
+# 採掘不可にする
+effect give @s minecraft:mining_fatigue infinite 255

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -72,6 +72,7 @@ scoreboard objectives add FearTimer dummy {"text":"畏怖タイマー"}
 scoreboard objectives add FearInterval dummy {"text":"畏怖インターバル"}
 scoreboard objectives add CurseResistance dummy {"text":"呪蝕耐性"}
 scoreboard objectives add CurseTimer dummy {"text":"呪蝕タイマー"}
+scoreboard objectives add RevivalSicknessTimer dummy {"text":"復活酔いタイマー"}
 scoreboard objectives add GameTime dummy {"text":"ゲームタイム"}
 scoreboard objectives add ProjectileTime minecraft.custom:minecraft.play_time {"text":"投射物ヒットタイマー"}
 scoreboard objectives add ShieldUsingTick dummy {"text":"盾を使用したtick"}

--- a/data/makeup/function/effect/player_debuff/revival_sickness/apply.mcfunction
+++ b/data/makeup/function/effect/player_debuff/revival_sickness/apply.mcfunction
@@ -1,0 +1,4 @@
+#> makeup:effect/player_debuff/revival_sickness/apply
+#
+# 復活酔い 付与メッセージ
+tellraw @s [{"translate":"%1$sは%2$sにかかった！","color":"red","with":[{"selector":"@s","color":"white"},{"interpret":true,"storage":"effect:","nbt":"BadEffectsName.RevivalSicknesss"}]}]

--- a/data/makeup/function/effect/player_debuff/revival_sickness/cure.mcfunction
+++ b/data/makeup/function/effect/player_debuff/revival_sickness/cure.mcfunction
@@ -1,0 +1,4 @@
+#> makeup:effect/player_debuff/revival_sickness/cure
+#
+# 復活酔い 回復メッセージ
+tellraw @s [{"translate":"%1$sは%2$sから回復した！","color":"green","with":[{"selector":"@s","color":"white"},{"interpret":true,"storage":"effect:","nbt":"BadEffectsName.RevivalSicknesss"}]}]

--- a/data/player/function/one_second.mcfunction
+++ b/data/player/function/one_second.mcfunction
@@ -13,6 +13,7 @@ execute if entity @s[scores={DoomCount=1..}] run function effect:doom/proceed
 execute if entity @s[scores={PalsyLevel=1..}] run function effect:palsy/tick
 execute if entity @s[scores={TntCount=0..}] if block ~ ~ ~ water run function effect:tnt/cure
 execute if entity @s[scores={VirusCount=1..}] run function effect:virus/tick
+execute if entity @s[scores={RevivalSicknessTimer=1..}] run function effect:player_debuff/revival_sickness/second
 
 # 祈り表示
 execute if entity @s[scores={Job=1..},tag=Pray] run function player:pray

--- a/data/settings/function/effect/too_bad_effects.mcfunction
+++ b/data/settings/function/effect/too_bad_effects.mcfunction
@@ -20,3 +20,4 @@ data modify storage effect: BadEffectsName.Virus set value '{"translate":"病気
 data modify storage effect: BadEffectsName.Tnt set value '{"translate":"トント","hoverEvent":{"action":"show_text","value":{"translate":"一定回数ダメージを受けると爆発する。","color":"white"}},"color":"white"}'
 data modify storage effect: BadEffectsName.Pale set value '{"translate":"ペイル","hoverEvent":{"action":"show_text","value":{"translate":"最大体力が減少する。","color":"white"}},"color":"white"}'
 data modify storage effect: BadEffectsName.Debility set value '{"translate":"衰弱","hoverEvent":{"action":"show_text","value":{"translate":"体力が一列になる。","color":"white"}},"color":"white"}'
+data modify storage effect: BadEffectsName.RevivalSicknesss set value '{"translate":"復活酔い","hoverEvent":{"action":"show_text","value":{"translate":"ブロックを掘れなくなる。","color":"white"}},"color":"white"}'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-992
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
バランス調整のため、アレイズなどの復活時に付与される採掘速度低下デバフ「復活酔い」を実装した。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
・新規スコア・メッセージ用ストレージの追加
・effect空間に"player_debuff"フォルダを追加
・時間経過の都合上1秒だと違和感が大きかったため、ピクニックの復活酔い付与時間を2秒に変更
## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
・他のプレイヤーデバフの移動
・アレイズ・先払い復元機の対応
## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
・難易度によって付与される時間が変わる。
・効果中に再度付与された場合、効果時間が2倍になる。
## レビュー観点<!-- なかったらこの項目を削除してください -->
<!-- - 想定通りに動作するか？ -->
<!-- - 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ -->
・マルチ判定は暫定なので、よりよい方法があれば提案してほしい。

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
