### PR TITLE
魔法ダメージのダメージ計算処理

### DIFF
--- a/data/entity/function/damage/apply/core/.mcfunction
+++ b/data/entity/function/damage/apply/core/.mcfunction
@@ -9,10 +9,6 @@ execute if data storage entity:_ damage{value:0d} run return fail
 # 実行者が死亡していれば中断
 execute if predicate entity:damage/check_death run return fail
 
-
-# ダメージ値が割合設定ならば解決する
-execute if data storage entity:_ damage.value{} run function entity:damage/apply/core/resolve_percentage_damage/
-
 # 実行者のentity_typeによって処理を変更する
 execute if entity @s[type=player] run function entity:damage/apply/core/player
 execute unless entity @s[type=player] run function entity:damage/apply/core/mob

--- a/data/entity/function/damage/apply/core/get_magic_defense.mcfunction
+++ b/data/entity/function/damage/apply/core/get_magic_defense.mcfunction
@@ -1,0 +1,12 @@
+#> entity:damage/apply/core/get_magic_defense
+
+execute unless entity @s[type=player] run return run scoreboard players get @s MagicDefense
+
+# プレイヤーの魔法防御力はエンチャントから計算する
+function player:load_equipments
+
+data modify storage calc: List set value []
+# data modify storage calc: List append from storage item: Equipments[].components."minecraft:enchantments".levels
+execute store result score _ _ run function calc:list/sum/x1
+# 2倍にして魔法防御力とする
+return run scoreboard players operation _ _ += _ _

--- a/data/entity/function/damage/apply/magic.mcfunction
+++ b/data/entity/function/damage/apply/magic.mcfunction
@@ -8,6 +8,19 @@ data modify storage entity:_ damage.value set from storage entity: damage.magic
 # ダメージ値が割合設定ならば解決する
 execute if data storage entity:_ damage.value{} run function entity:damage/apply/core/resolve_percentage_damage/
 
+# 軽減率を計算
+execute store result score _ MagicDefense run function entity:damage/apply/core/get_magic_defense
+# 75=軽減率調整用の数値 100倍で計算
+scoreboard players add _ MagicDefense 75
+scoreboard players set _ _ 7500
+scoreboard players operation _ _ /= _ MagicDefense
+
+execute store result score _ Calc run data get storage entity:_ damage.value 100
+
+# Shieldの処理を入れる
+# scoreboard players operation _ Calc -= @s Sheild?
+execute store result storage entity:_ damage.value double 0.0001 run scoreboard players operation _ Calc *= _ _
+
 # core処理を実行
 function entity:damage/apply/core/
 

--- a/data/entity/function/damage/apply/magic.mcfunction
+++ b/data/entity/function/damage/apply/magic.mcfunction
@@ -5,6 +5,9 @@
 data modify storage entity:_ damage set value {type:"entity:magic"}
 data modify storage entity:_ damage.value set from storage entity: damage.magic
 
+# ダメージ値が割合設定ならば解決する
+execute if data storage entity:_ damage.value{} run function entity:damage/apply/core/resolve_percentage_damage/
+
 # core処理を実行
 function entity:damage/apply/core/
 

--- a/data/entity/function/damage/apply/physical.mcfunction
+++ b/data/entity/function/damage/apply/physical.mcfunction
@@ -5,6 +5,9 @@
 data modify storage entity:_ damage set value {type:"entity:physical"}
 data modify storage entity:_ damage.value set from storage entity: damage.physical
 
+# ダメージ値が割合設定ならば解決する
+execute if data storage entity:_ damage.value{} run function entity:damage/apply/core/resolve_percentage_damage/
+
 # core処理を実行
 function entity:damage/apply/core/
 

--- a/data/entity/function/damage/apply/unreasonable.mcfunction
+++ b/data/entity/function/damage/apply/unreasonable.mcfunction
@@ -5,6 +5,9 @@
 data modify storage entity:_ damage set value {type:"entity:unreasonable"}
 data modify storage entity:_ damage.value set from storage entity: damage.unreasonable
 
+# ダメージ値が割合設定ならば解決する
+execute if data storage entity:_ damage.value{} run function entity:damage/apply/core/resolve_percentage_damage/
+
 # core処理を実行
 function entity:damage/apply/core/
 

--- a/data/entity/tags/damage_type/magic.json
+++ b/data/entity/tags/damage_type/magic.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "entity:magic"
+  ]
+}

--- a/data/entity/tags/damage_type/physical.json
+++ b/data/entity/tags/damage_type/physical.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "entity:physical"
+  ]
+}

--- a/data/entity/tags/damage_type/unreasonable.json
+++ b/data/entity/tags/damage_type/unreasonable.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "entity:unreasonable"
+  ]
+}

--- a/data/minecraft/tags/damage_type/bypasses_armor.json
+++ b/data/minecraft/tags/damage_type/bypasses_armor.json
@@ -1,6 +1,6 @@
 {
   "values": [
-    "tusb:unreasonable",
-    "tusb:magic"
+    "#entity:magic",
+    "#entity:unreasonable"
   ]
 }

--- a/data/minecraft/tags/damage_type/bypasses_cooldown.json
+++ b/data/minecraft/tags/damage_type/bypasses_cooldown.json
@@ -1,7 +1,7 @@
 {
   "values": [
-    "entity:physical",
-    "entity:magic",
-    "entity:unreasonable"
+    "#entity:physical",
+    "#entity:magic",
+    "#entity:unreasonable"
   ]
 }

--- a/data/minecraft/tags/damage_type/bypasses_effects.json
+++ b/data/minecraft/tags/damage_type/bypasses_effects.json
@@ -1,5 +1,6 @@
 {
   "values": [
-    "tusb:unreasonable"
+    "#entity:magic",
+    "#entity:unreasonable"
   ]
 }

--- a/data/minecraft/tags/damage_type/bypasses_enchantments.json
+++ b/data/minecraft/tags/damage_type/bypasses_enchantments.json
@@ -1,5 +1,6 @@
 {
   "values": [
-    "tusb:unreasonable"
+    "#entity:magic",
+    "#entity:unreasonable"
   ]
 }

--- a/data/minecraft/tags/damage_type/bypasses_invulnerability.json
+++ b/data/minecraft/tags/damage_type/bypasses_invulnerability.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "tusb:unreasonable"
-  ]
-}

--- a/data/minecraft/tags/damage_type/bypasses_resistance.json
+++ b/data/minecraft/tags/damage_type/bypasses_resistance.json
@@ -1,5 +1,6 @@
 {
   "values": [
-    "tusb:unreasonable"
+    "#entity:magic",
+    "#entity:unreasonable"
   ]
 }

--- a/data/minecraft/tags/damage_type/bypasses_shield.json
+++ b/data/minecraft/tags/damage_type/bypasses_shield.json
@@ -1,5 +1,5 @@
 {
   "values": [
-    "tusb:unreasonable"
+    "#entity:unreasonable"
   ]
 }

--- a/data/minecraft/tags/damage_type/no_knockback.json
+++ b/data/minecraft/tags/damage_type/no_knockback.json
@@ -1,7 +1,7 @@
 {
   "values": [
-    "entity:physical",
-    "entity:magic",
-    "entity:unreasonable"
+    "#entity:physical",
+    "#entity:magic",
+    "#entity:unreasonable"
   ]
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-996
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
魔法ダメージをコマンドで軽減する処理を追加
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* 魔法、理外のダメージを防具や耐性で軽減できないように変更
  → コマンドでdamageコマンドの値を変える必要がある
* 魔法ダメージの軽減式を実装
## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
* 魔法ダメージ軽減のエンチャントに対応していない
* Shieldステータスを計算に考慮できていない
## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
`entity:damage/apply/core/get_magic_defense`の4行目に以下のコマンドを追加してプレイヤーの魔法防御力を調整してください
```mcfunction
execute if entity @s[type=player] run return run scoreboard players get @s MagicDefense
```
```mcfunction
data modify storage entity: damage set value {magic:10}
# MagicDefenseの値で軽減されることを確認してください
execute as @.p at @s run function entity:damage/apply/
```

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
