### PR TITLE
Mobステータスの計算式を変更

### DIFF
--- a/data/entity/function/damage/apply/magic.mcfunction
+++ b/data/entity/function/damage/apply/magic.mcfunction
@@ -18,7 +18,8 @@ scoreboard players operation _ _ /= _ MagicDefense
 execute store result score _ Calc run data get storage entity:_ damage.value 100
 
 # Shieldの処理を入れる
-# scoreboard players operation _ Calc -= @s Sheild?
+scoreboard players operation _ Calc -= @s Shield
+execute if score _ Calc matches ..-1 run scoreboard players set _ Calc 0
 execute store result storage entity:_ damage.value double 0.0001 run scoreboard players operation _ Calc *= _ _
 
 # core処理を実行

--- a/data/entity/function/spawn/apply_status/mob.mcfunction
+++ b/data/entity/function/spawn/apply_status/mob.mcfunction
@@ -20,6 +20,7 @@ function entity:spawn/apply_status/status/mp
 function entity:spawn/apply_status/status/defense
 function entity:spawn/apply_status/status/magic_defense
 function entity:spawn/apply_status/status/unreasonable_defense
+function entity:spawn/apply_status/status/shield
 
 scoreboard players operation @s HP = @s HPMax
 scoreboard players operation @s MP = @s MPMax

--- a/data/entity/function/spawn/apply_status/status/attack.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/attack.mcfunction
@@ -1,8 +1,8 @@
 #> entity:spawn/apply_status/status/attack
 
 ### 物理攻撃力を計算する
-execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理攻撃力" 100
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理攻撃力" 100
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理攻撃力".baseStatus 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理攻撃力".status 100
 execute store result score @s Attack run function entity:spawn/apply_status/status/calc
 
 ### 投射物の攻撃力適用

--- a/data/entity/function/spawn/apply_status/status/attack.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/attack.mcfunction
@@ -1,10 +1,10 @@
 #> entity:spawn/apply_status/status/attack
-scoreboard players set _ _ 100
+
 ### 物理攻撃力を計算する
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理攻撃力" 0.5
-scoreboard players operation _ Calc *= @s Level
-scoreboard players operation _ Calc /= _ _
-execute store result score @s Attack run scoreboard players add _ Calc 2
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理攻撃力" 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理攻撃力" 100
+execute store result score @s Attack run function entity:spawn/apply_status/status/calc
+
 ### 投射物の攻撃力適用
 execute store result entity @s[type=#arrows,scores={Attack=1..}] damage double 1 run scoreboard players get @s Attack
 tag @s[type=#entity:projectiles,type=!#arrows,scores={Attack=1..}] add DamageProjectile

--- a/data/entity/function/spawn/apply_status/status/calc.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/calc.mcfunction
@@ -1,0 +1,13 @@
+#> entity:spawn/apply_status/status/calc
+# 
+# baseStatus + status * Level
+# 
+# _ _ = baseStatus
+# _ Calc = status
+# @s Level = Level
+#
+
+scoreboard players operation _ Calc *= @s Level
+scoreboard players operation _ _ += _ Calc
+scoreboard players set _ Calc 100
+return run scoreboard players operation _ _ /= _ Calc

--- a/data/entity/function/spawn/apply_status/status/defense.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/defense.mcfunction
@@ -1,6 +1,6 @@
 #> entity:spawn/apply_status/status/defense
 
 ### 物理防御力を計算する
-execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理防御力" 100
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理防御力" 100
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理防御力".baseStatus 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理防御力".status 100
 execute store result score @s Defense run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/defense.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/defense.mcfunction
@@ -1,7 +1,6 @@
 #> entity:spawn/apply_status/status/defense
-scoreboard players set _ _ 100
+
 ### 物理防御力を計算する
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理防御力" 1
-scoreboard players operation _ Calc *= @s Level
-scoreboard players operation _ Calc /= _ _
-execute store result score @s Defense run scoreboard players add _ Calc 5
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理防御力" 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."物理防御力" 100
+execute store result score @s Defense run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/hp.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/hp.mcfunction
@@ -1,6 +1,6 @@
 #> entity:spawn/apply_status/status/hp
 
 ### 最大HPを計算する
-execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."最大HP" 100
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."最大HP" 100
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."最大HP".baseStatus 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."最大HP".status 100
 execute store result score @s HPMax run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/hp.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/hp.mcfunction
@@ -1,8 +1,6 @@
 #> entity:spawn/apply_status/status/hp
-scoreboard players set _ _ 100
+
 ### 最大HPを計算する
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."最大HP" 4
-scoreboard players operation _ Calc *= @s Level
-scoreboard players operation _ Calc /= _ _
-scoreboard players operation _ Calc += @s Level
-execute store result score @s HPMax run scoreboard players add _ Calc 10
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."最大HP" 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."最大HP" 100
+execute store result score @s HPMax run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/magic_attack.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/magic_attack.mcfunction
@@ -1,6 +1,6 @@
 #> entity:spawn/apply_status/status/magic_attack
 
 ### 魔法攻撃力を計算する
-execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法攻撃力" 100
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法攻撃力" 100
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法攻撃力".baseStatus 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法攻撃力".status 100
 execute store result score @s MagicAttack run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/magic_attack.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/magic_attack.mcfunction
@@ -1,7 +1,6 @@
-#> entity:spawn/apply_status/status/special_attack
-scoreboard players set _ _ 100
+#> entity:spawn/apply_status/status/magic_attack
+
 ### 魔法攻撃力を計算する
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法攻撃力" 0.5
-scoreboard players operation _ Calc *= @s Level
-scoreboard players operation _ Calc /= _ _
-execute store result score @s MagicAttack run scoreboard players add _ Calc 2
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法攻撃力" 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法攻撃力" 100
+execute store result score @s MagicAttack run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/magic_defense.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/magic_defense.mcfunction
@@ -1,6 +1,6 @@
 #> entity:spawn/apply_status/status/magic_defense
 
 ### 魔法防御力を計算する
-execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法防御力" 100
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法防御力" 100
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法防御力".baseStatus 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法防御力".status 100
 execute store result score @s MagicDefense run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/magic_defense.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/magic_defense.mcfunction
@@ -1,7 +1,6 @@
-#> entity:spawn/apply_status/status/special_defense
-scoreboard players set _ _ 100
+#> entity:spawn/apply_status/status/magic_defense
+
 ### 魔法防御力を計算する
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法防御力" 1
-scoreboard players operation _ Calc *= @s Level
-scoreboard players operation _ Calc /= _ _
-execute store result score @s MagicDefense run scoreboard players add _ Calc 5
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法防御力" 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法防御力" 100
+execute store result score @s MagicDefense run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/shield.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/shield.mcfunction
@@ -1,0 +1,5 @@
+#> entity:spawn/apply_status/status/shield
+
+# Shield
+# 魔法属性ダメージの固定防御力
+execute store result score @s Shield run data get storage tusb_mob: "遅延ステータス"."ステータス"."魔法シールド"

--- a/data/entity/function/spawn/apply_status/status/unreasonable_attack.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/unreasonable_attack.mcfunction
@@ -1,7 +1,6 @@
 #> entity:spawn/apply_status/status/unreasonable_attack
-scoreboard players set _ _ 100
+
 ### 理外攻撃力を計算する
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外攻撃力" 0.5
-scoreboard players operation _ Calc *= @s Level
-scoreboard players operation _ Calc /= _ _
-execute store result score @s UnreasonableAttack run scoreboard players add _ Calc 2
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外攻撃力" 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外攻撃力" 100
+execute store result score @s UnreasonableAttack run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/unreasonable_attack.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/unreasonable_attack.mcfunction
@@ -1,6 +1,6 @@
 #> entity:spawn/apply_status/status/unreasonable_attack
 
 ### 理外攻撃力を計算する
-execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外攻撃力" 100
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外攻撃力" 100
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外攻撃力".baseStatus 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外攻撃力".status 100
 execute store result score @s UnreasonableAttack run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/unreasonable_defense.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/unreasonable_defense.mcfunction
@@ -1,7 +1,6 @@
 #> entity:spawn/apply_status/status/unreasonable_defense
-scoreboard players set _ _ 100
+
 ### 理外防御力を計算する
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外防御力" 1
-scoreboard players operation _ Calc *= @s Level
-scoreboard players operation _ Calc /= _ _
-execute store result score @s UnreasonableDefense run scoreboard players add _ Calc 5
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外防御力" 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外防御力" 100
+execute store result score @s UnreasonableDefense run function entity:spawn/apply_status/status/calc

--- a/data/entity/function/spawn/apply_status/status/unreasonable_defense.mcfunction
+++ b/data/entity/function/spawn/apply_status/status/unreasonable_defense.mcfunction
@@ -1,6 +1,6 @@
 #> entity:spawn/apply_status/status/unreasonable_defense
 
 ### 理外防御力を計算する
-execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外防御力" 100
-execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外防御力" 100
+execute store result score _ _ run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外防御力".baseStatus 100
+execute store result score _ Calc run data get storage tusb_mob: "遅延ステータス"."ステータス"."理外防御力".status 100
 execute store result score @s UnreasonableDefense run function entity:spawn/apply_status/status/calc

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -43,6 +43,7 @@ scoreboard objectives add StoredDamage dummy {"text":"累積ダメージ"}
 scoreboard objectives add Health health {"text":"HP"}
 scoreboard objectives setdisplay below_name Health
 scoreboard objectives add NativeFlag dummy {"text":"常時実行フラグ"}
+scoreboard objectives add Shield dummy {"text": "Shield"}
 
 ###アイテム
 scoreboard objectives add EnchantLevel dummy {"text":"エンチャントレベル"}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-998
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
Mobステータスの式を変更する
`baseStatus + status * Level`
MPはすでに旧式での値がMobに使われているため式を変更しない。

`Shield`を追加する。魔法属性ダメージを減算する。これは成長ステータスではない。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* ステータス計算のための共通functionを追加
* MP以外のすべてのステータスを共通functionを使って計算する
* `Shield`オブジェクトを追加
* 魔法シールドの値を保存する
## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
* `baseStatus`と`status`の値の保存方法が固まっていないため、そこから値を取り出して計算できていない
## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
共通functionで正しく計算できていれば、すべてのステータスの計算は大丈夫です。

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
