### PR TITLE
状態異常耐性の仕組みを刷新

### DIFF
--- a/data/effect/advancement/bad_effects.json
+++ b/data/effect/advancement/bad_effects.json
@@ -102,7 +102,24 @@
               "max": 126
             }
           }
-        }
+        },
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "effects": {
+                  "mining_fatigue": {
+                    "amplifier": 2,
+                    "duration": 6000
+                  }
+                }
+              }
+            }
+          }
+        ]
       }
     },
     "slowness": {

--- a/data/effect/function/bad_effects.mcfunction
+++ b/data/effect/function/bad_effects.mcfunction
@@ -1,67 +1,47 @@
 #> effect:bad_effects
-###免疫発動(するかも)
+###免疫発動
 
-scoreboard players set _ ResistLock 0
+say a
+
+execute if predicate effect:resist run function makeup:effect/bad_effects
+scoreboard players set @s ResistLock 0
 
 #吐き気
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={nausea=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s nausea
+execute if entity @s[advancements={effect:bad_effects={nausea=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.nausea
+effect clear @s[scores={ResistLock=1}] nausea
 
 #毒
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={poison=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s poison
+execute if entity @s[advancements={effect:bad_effects={poison=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.poison
+effect clear @s[scores={ResistLock=1}] poison
 
 #弱体化
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={weakness=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s weakness
+execute if entity @s[advancements={effect:bad_effects={weakness=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.weakness
+effect clear @s[scores={ResistLock=1}] weakness
 
 #ウィザー
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={wither=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s wither
+execute if entity @s[advancements={effect:bad_effects={wither=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.wither
+effect clear @s[scores={ResistLock=1}] wither
 
 #盲目
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={blindness=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s blindness
+execute if entity @s[advancements={effect:bad_effects={blindness=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.blindness
+effect clear @s[scores={ResistLock=1}] blindness
 
 #空腹
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={hunger=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s hunger
+execute if entity @s[advancements={effect:bad_effects={hunger=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.hunger
+effect clear @s[scores={ResistLock=1}] hunger
 
 #採掘速度低下
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={mining_fatigue=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s mining_fatigue
+execute if entity @s[advancements={effect:bad_effects={mining_fatigue=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.mining_fatigue
+effect clear @s[scores={ResistLock=1}] mining_fatigue
 
 #移動速度低下
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={slowness=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s slowness
+execute if entity @s[advancements={effect:bad_effects={slowness=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.slowness
+effect clear @s[scores={ResistLock=1}] slowness
 
 #暗闇
-execute store result score _ ResistEffects run function calc:random
-scoreboard players set _ _ 100
-scoreboard players operation _ ResistEffects %= _ _
-execute if entity @s[advancements={effect:bad_effects={darkness=true}}] if score _ ResistEffects < @s ResistEffects store success score _ ResistLock run effect clear @s darkness
+execute if entity @s[advancements={effect:bad_effects={darkness=true}},predicate=effect:resist] store success score @s ResistLock run function effect:resist with storage effect: resist.bad_effect.darkness
+effect clear @s[scores={ResistLock=1}] darkness
 
 execute if entity @a[distance=..32,scores={Burst=0..,Job=4}] run function skill:act/white_mage/clear/cure/level2
-execute if entity @a[distance=..32,scores={Burst=0..,Job=4}] run scoreboard players set @s ResistLock 1
-
-execute unless score @s ResistLock matches 1 if score _ ResistLock matches 1.. run function makeup:effect/bad_effects
-execute unless score @s ResistLock matches 1 if score _ ResistLock matches ..0 run scoreboard players add @s ResistEffects 3
-scoreboard players set @s ResistLock 1
 
 advancement revoke @s only effect:bad_effects

--- a/data/effect/function/bad_effects.mcfunction
+++ b/data/effect/function/bad_effects.mcfunction
@@ -1,8 +1,6 @@
 #> effect:bad_effects
 ###免疫発動
 
-say a
-
 execute if predicate effect:resist run function makeup:effect/bad_effects
 scoreboard players set @s ResistLock 0
 

--- a/data/effect/function/resist.mcfunction
+++ b/data/effect/function/resist.mcfunction
@@ -9,5 +9,7 @@ data modify storage entity: damage set value {unreasonable:0}
 execute store result storage entity: damage.unreasonable int 1 run scoreboard players get _ ResistEffects
 
 function entity:damage/apply/unreasonable
+# １未満の緩衝体力の時はエフェクト解除
+execute if score _ ResistEffects matches 0 run effect clear @s absorption
 
 return 1

--- a/data/effect/function/resist.mcfunction
+++ b/data/effect/function/resist.mcfunction
@@ -1,10 +1,13 @@
 #> effect:resist
-###状態異常耐性減少
+### 異常状態耐性発動
 
-scoreboard players remove @s ResistEffects 1
-scoreboard players remove @s[scores={ResistEffects=101..}] ResistEffects 1
-# 状態異常耐性下限の名残
-scoreboard players set _ _ 0
-scoreboard players operation @s ResistEffects > _ _
-# scoreboard players set _ _ 100
-# scoreboard players operation @s ResistEffects < _ _
+execute store result score @s ResistEffects run data get entity @s AbsorptionAmount
+$scoreboard players set _ ResistEffects $(value)
+scoreboard players operation _ ResistEffects < @s ResistEffects
+
+data modify storage entity: damage set value {unreasonable:0}
+execute store result storage entity: damage.unreasonable int 1 run scoreboard players get _ ResistEffects
+
+function entity:damage/apply/unreasonable
+
+return 1

--- a/data/effect/function/shorten_bullet.mcfunction
+++ b/data/effect/function/shorten_bullet.mcfunction
@@ -9,4 +9,3 @@ execute if predicate effect:resist run return run function effect:resist with st
 
 ###エフェクト付与
 effect give @s minecraft:levitation 1 11
-  

--- a/data/effect/function/shorten_bullet.mcfunction
+++ b/data/effect/function/shorten_bullet.mcfunction
@@ -1,8 +1,12 @@
 #> effect:shorten_bullet
 ### シャルカーバレットカスタマイズ
 
+effect clear @s minecraft:levitation
+advancement revoke @s only effect:shorten_bullet
+
+execute if predicate effect:resist run function makeup:effect/bad_effects
+execute if predicate effect:resist run return run function effect:resist with storage effect: resist.bad_effect.shulker_bullet
 
 ###エフェクト付与
-effect clear @s minecraft:levitation
 effect give @s minecraft:levitation 1 11
-advancement revoke @s only effect:shorten_bullet
+  

--- a/data/effect/function/shorten_curse.mcfunction
+++ b/data/effect/function/shorten_curse.mcfunction
@@ -1,11 +1,16 @@
 #> effect:shorten_curse
 ### ガーディアンの呪いカスタマイズ
 
+say shorten
+
+###進捗トリガーリセット
+effect clear @s minecraft:mining_fatigue
+advancement revoke @s only effect:shorten_curse
+
+execute if predicate effect:resist run function makeup:effect/bad_effects
+execute if predicate effect:resist run return run function effect:resist with storage effect: resist.bad_effect.elder_guardian
 
 ###エフェクト付与
-effect clear @s minecraft:mining_fatigue
 effect give @s minecraft:mining_fatigue 15 3
 effect give @s minecraft:weakness 15 3
 effect give @s minecraft:hunger 15 3
-###進捗トリガーリセット
-advancement revoke @s only effect:shorten_curse

--- a/data/effect/function/shorten_curse.mcfunction
+++ b/data/effect/function/shorten_curse.mcfunction
@@ -1,8 +1,6 @@
 #> effect:shorten_curse
 ### ガーディアンの呪いカスタマイズ
 
-say shorten
-
 ###進捗トリガーリセット
 effect clear @s minecraft:mining_fatigue
 advancement revoke @s only effect:shorten_curse

--- a/data/effect/function/too_bad_effect.mcfunction
+++ b/data/effect/function/too_bad_effect.mcfunction
@@ -1,22 +1,30 @@
 #> effect:too_bad_effect
 ### 特殊デバフ処理
 
-execute if entity @a[distance=..32,scores={Burst=0..,Job=4}] run scoreboard players set @s ResistLock 1
+execute if predicate effect:resist run function makeup:effect/too_bad_effect
 
-execute unless score @s ResistLock matches 1 unless score _ ResistEffects < @s ResistEffects run scoreboard players add @s ResistEffects 5
-execute unless score @s ResistLock matches 1 if score _ ResistEffects < @s ResistEffects run function makeup:effect/too_bad_effect
-execute if score _ ResistEffects < @s ResistEffects run advancement revoke @s only effect:invisible
-
-execute if entity @s[advancements={effect:invisible={doom=true}}] run function effect:doom/apply
-execute if entity @s[advancements={effect:invisible={super_doom=true}}] run function effect:doom/apply_super
-execute if entity @s[advancements={effect:invisible={burn=true}}] run function effect:burn/apply
-execute if entity @s[advancements={effect:invisible={freeze=true}}] run function effect:freeze/apply0
-execute if entity @s[advancements={effect:invisible={palsy=true}}] run function effect:palsy/apply
-execute if entity @s[advancements={effect:invisible={confuse=true}}] run function effect:confuse/apply
-execute if entity @s[advancements={effect:invisible={curse=true}}] run function effect:curse/apply
-execute if entity @s[advancements={effect:invisible={virus=true}}] run function effect:virus/apply
-execute if entity @s[advancements={effect:invisible={tnt=true}}] run function effect:tnt/apply
-execute if entity @s[advancements={effect:invisible={pale=true}}] run function effect:pale/apply
-execute if entity @s[advancements={effect:invisible={debility=true}}] run function effect:debility/apply
+execute if entity @s[advancements={effect:invisible={doom=true}}] unless predicate effect:resist run function effect:doom/apply
+execute if entity @s[advancements={effect:invisible={doom=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.doom
+execute if entity @s[advancements={effect:invisible={super_doom=true}}] unless predicate effect:resist run function effect:doom/apply_super
+execute if entity @s[advancements={effect:invisible={super_doom=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.doom_super
+execute if entity @s[advancements={effect:invisible={burn=true}}] unless predicate effect:resist run function effect:burn/apply
+execute if entity @s[advancements={effect:invisible={burn=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.burn
+execute if entity @s[advancements={effect:invisible={freeze=true}}] unless predicate effect:resist run function effect:freeze/apply0
+execute if entity @s[advancements={effect:invisible={freeze=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.freeze
+execute if entity @s[advancements={effect:invisible={palsy=true}}] unless predicate effect:resist run function effect:palsy/apply
+execute if entity @s[advancements={effect:invisible={palsy=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.palsy
+execute if entity @s[advancements={effect:invisible={confuse=true}}] unless predicate effect:resist run function effect:confuse/apply
+execute if entity @s[advancements={effect:invisible={confuse=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.confuse
+execute if entity @s[advancements={effect:invisible={curse=true}}] unless predicate effect:resist run function effect:curse/apply
+execute if entity @s[advancements={effect:invisible={curse=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.curse
+execute if entity @s[advancements={effect:invisible={virus=true}}] unless predicate effect:resist run function effect:virus/apply
+execute if entity @s[advancements={effect:invisible={virus=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.virus
+execute if entity @s[advancements={effect:invisible={tnt=true}}] unless predicate effect:resist run function effect:tnt/apply
+execute if entity @s[advancements={effect:invisible={tnt=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.tnt
+execute if entity @s[advancements={effect:invisible={pale=true}}] unless predicate effect:resist run function effect:pale/apply
+# ペイルはその生での２度目以降は減少を受けない
+execute if entity @s[advancements={effect:invisible={pale=true}}] unless score @s PaleLevel matches ..-1 if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.pale
+execute if entity @s[advancements={effect:invisible={debility=true}}] unless predicate effect:resist run function effect:debility/apply
+execute if entity @s[advancements={effect:invisible={debility=true}}] if predicate effect:resist run function effect:resist with storage effect: resist.too_bad_effect.debility
 
 execute if entity @a[distance=..32,scores={Burst=0..,Job=4}] run function skill:act/white_mage/clear/cure/level4

--- a/data/effect/predicate/resist.json
+++ b/data/effect/predicate/resist.json
@@ -1,0 +1,9 @@
+{
+  "condition": "entity_properties",
+  "entity": "this",
+  "predicate": {
+    "effects": {
+      "absorption": {}
+    }
+  }
+}

--- a/data/main/function/difficulty/select/common.mcfunction
+++ b/data/main/function/difficulty/select/common.mcfunction
@@ -14,3 +14,6 @@ schedule function main:difficulty/select/end 13t replace
 
 # 難易度変更演出
 function makeup:main/difficulty/select/common
+
+# 状態異常耐性の減少量更新
+function settings:effect/resist

--- a/data/player/function/one_second.mcfunction
+++ b/data/player/function/one_second.mcfunction
@@ -2,10 +2,6 @@
 # -> 10秒処理
 execute if score $Seconds Count matches 0 run function player:ten_seconds
 
-###状態異常耐性
-execute if entity @s[scores={ResistEffects=1..}] run function effect:resist
-scoreboard players reset @s[scores={ResistLock=1..}] ResistLock
-
 ###特殊デバフ処理
 execute if entity @s[scores={BurnCount=0..}] run function effect:burn/tick
 execute if entity @s[scores={ConfuseCount=1..}] run function effect:confuse/tick

--- a/data/settings/function/effect/resist.mcfunction
+++ b/data/settings/function/effect/resist.mcfunction
@@ -2,7 +2,7 @@
 
 data remove storage effect: resist
 
-data modify storage effect: resist set value {\
+execute if data storage main: difficult{world:"picnic"} run data modify storage effect: resist set value {\
   bad_effect:{\
     nausea:{value:1},\
     poison:{value:3},\
@@ -10,11 +10,81 @@ data modify storage effect: resist set value {\
     wither:{value:4},\
     blindness:{value:3},\
     hunger:{value:2},\
-    mining_fatigue:{value:3},\
-    slowness:{value:1},\
+    mining_fatigue:{value:2},\
+    slowness:{value:2},\
     darkness:{value:4},\
     shulker_bullet:{value:2},\
-    elder_guardian:{value:10}\
+    elder_guardian:{value:10},\
   },\
-  too_bad_effect:{}\
+  too_bad_effect:{\
+    doom:{value:16},\
+    doom_super:{value:2147483647},\
+    burn:{value:8},\
+    freeze:{value:16},\
+    palsy:{value:8},\
+    confuse:{value:8},\
+    curse:{value:8},\
+    virus:{value:16},\
+    tnt:{value:8},\
+    pale:{value:2147483647},\
+    debility:{value:32},\
+  }\
+}
+
+execute unless data storage main: difficult{world:"picnic"} unless data storage main: difficult{world:"expart"} run data modify storage effect: resist set value {\
+  bad_effect:{\
+    nausea:{value:1},\
+    poison:{value:3},\
+    weakness:{value:2},\
+    wither:{value:4},\
+    blindness:{value:3},\
+    hunger:{value:2},\
+    mining_fatigue:{value:2},\
+    slowness:{value:2},\
+    darkness:{value:4},\
+    shulker_bullet:{value:2},\
+    elder_guardian:{value:10},\
+  },\
+  too_bad_effect:{\
+    doom:{value:16},\
+    doom_super:{value:2147483647},\
+    burn:{value:8},\
+    freeze:{value:16},\
+    palsy:{value:8},\
+    confuse:{value:8},\
+    curse:{value:8},\
+    virus:{value:16},\
+    tnt:{value:8},\
+    pale:{value:2147483647},\
+    debility:{value:32},\
+  }\
+}
+
+execute if data storage main: difficult{world:"expart"} run data modify storage effect: resist set value {\
+  bad_effect:{\
+    nausea:{value:1},\
+    poison:{value:3},\
+    weakness:{value:2},\
+    wither:{value:4},\
+    blindness:{value:3},\
+    hunger:{value:2},\
+    mining_fatigue:{value:2},\
+    slowness:{value:2},\
+    darkness:{value:4},\
+    shulker_bullet:{value:2},\
+    elder_guardian:{value:10},\
+  },\
+  too_bad_effect:{\
+    doom:{value:16},\
+    doom_super:{value:2147483647},\
+    burn:{value:8},\
+    freeze:{value:16},\
+    palsy:{value:8},\
+    confuse:{value:8},\
+    curse:{value:8},\
+    virus:{value:16},\
+    tnt:{value:8},\
+    pale:{value:2147483647},\
+    debility:{value:32},\
+  }\
 }

--- a/data/settings/function/effect/resist.mcfunction
+++ b/data/settings/function/effect/resist.mcfunction
@@ -1,0 +1,20 @@
+#> settings:effect/resist
+
+data remove storage effect: resist
+
+data modify storage effect: resist set value {\
+  bad_effect:{\
+    nausea:{value:1},\
+    poison:{value:3},\
+    weakness:{value:2},\
+    wither:{value:4},\
+    blindness:{value:3},\
+    hunger:{value:2},\
+    mining_fatigue:{value:3},\
+    slowness:{value:1},\
+    darkness:{value:4},\
+    shulker_bullet:{value:2},\
+    elder_guardian:{value:10}\
+  },\
+  too_bad_effect:{}\
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-407
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
状態異常耐性を隠しステータスから、緩衝体力の有無へ変更した。
緩衝体力が存在する限りデバフを防ぐことができる。
デバフを受けた場合、設定された減少量の分だけ緩衝体力が減る。
理外属性のダメージを使って緩衝体力を減少させる。

減少量が緩衝体力を上回っているときは、緩衝体力をすべて失う。
このとき、普通の体力へダメージが入ることはない。

`settings:effect/resist`に各デバフの減少量が設定されており、難易度別に変更できる。

バニラのデバフは、デバフを受けているときに緩衝体力が付与されると即座に回復する。
ペイルは、その生で１度受けている場合、２度目以降受けるときに免疫は減少しない。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* 緩衝体力があるときはデバフを受けない、回復する
* デバフを受けた時に緩衝体力を減少させる
* デバフ、難易度ごとに減少量を設定できる
## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
* 難易度ごとの緩衝体力値の上限設定
## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
```mcfunction
# 緩衝体力の付与　金リンゴ・エンチャントされた金リンゴでも可
effect give @s absorption 30 <Amplifier>
```
何らかのデバフを受ける
https://github.com/TUSB/TheUnusualSkyBlock/wiki/%E7%89%B9%E6%AE%8A%E3%83%87%E3%83%90%E3%83%95

## レビュー観点<!-- なかったらこの項目を削除してください -->
<!-- - 想定通りに動作するか？ -->
<!-- - 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ -->
緩衝体力の減少はマクロでの実行にしました。
同時に複数種類の減少量を受けるとキャッシュの恩恵を受けられないけど、同じようなデバフを受け続ける場合はキャッシュの恩恵を受けられますね。

## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->
[まとめ OR アーカイブ - 免疫減少量](https://docs.google.com/spreadsheets/d/1Icw9t7pPoWfoGZ3vrS2agIL8D-FT8PUd9F1_c2D9LFc/edit?gid=1274416176#gid=1274416176&range=A1)
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
