### PR TITLE
バーストゲージの仕組みを変更

### DIFF
--- a/data/entity/function/death/act.mcfunction
+++ b/data/entity/function/death/act.mcfunction
@@ -10,5 +10,5 @@ execute if entity @s[scores={Kaishaku=1..},tag=!KaishakuExplosion] run function 
 execute if entity @s[scores={WildCooking=1..}] run function skill:act/hunter/wild_cooking/cook
 # ルートテーブルドロップ
 execute if entity @s[tag=HasLootTable] run function entity:loot/
-# バースト増加
-execute if entity @s[tag=Enemy,tag=!NonBurst] unless score $World Burst matches -1 run function skill:burst/add
+# バーストオーブドロップ
+execute if entity @s[tag=Enemy,tag=!NonBurst] run function player:burst/orb

--- a/data/entity/function/initialize_entity.mcfunction
+++ b/data/entity/function/initialize_entity.mcfunction
@@ -45,6 +45,9 @@ data modify entity @s[type=#entity:item_frames] Invulnerable set value 1b
 #SmartMotion E (反発係数)
 execute unless score @s[tag=SmartMotion] sm.E matches -2147483648..2147483647 run scoreboard players set @s sm.E 100
 
+# 未管理の経験値オーブを削除
+tag @s[type=experience_orb,tag=!BurstOrb] add Garbage
+
 #NativeFlag スコア付与 それぞれのタグで付与を独立させる
 scoreboard players add @s[tag=DamageProjectile] NativeFlag 1
 scoreboard players add @s[tag=SmartMotion] NativeFlag 1

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -34,6 +34,8 @@ scoreboard objectives add GrowTotal dummy {"text":"合計成長ポイント"}
 scoreboard objectives add Damage dummy {"text":"ダメージ"}
 scoreboard objectives add HealthHealing dummy {"text":"HP回復量"}
 scoreboard objectives add Age minecraft.custom:minecraft.time_since_death {"text":"生きている時間"}
+scoreboard objectives add BeforeXP dummy {"text":"前のXP量"}
+scoreboard objectives add XP xp {"text":"現在のXP量"}
 scoreboard objectives add ParticleDenom dummy {"text":"パーティクル表示割合"}
 scoreboard objectives add BreakSpawner dummy {"text":"スポナー破壊数"}
 scoreboard objectives add FoodLevel food {"text":"満腹度"}

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -110,6 +110,7 @@ scoreboard objectives add MPConsumption dummy {"text":"MP回復量"}
 scoreboard objectives add TrackingID dummy {"text":"追尾スキル同期ID"}
 scoreboard objectives add SkillShortcut dummy {"text":"スキル設定中tick"}
 scoreboard objectives add Burst dummy {"text":"バースト管理"}
+scoreboard objectives add BurstTimer dummy {"text":"バースト残り時間"}
 #剣士
 scoreboard objectives add FalconSlashTimer dummy {"text":"はやぶさ斬り遅延タイマー"}
 scoreboard objectives add IronWill dummy {"text":"アイアンウィル残りtick数"}
@@ -163,12 +164,6 @@ scoreboard objectives add Weakness dummy {"text":"ウィークペイント効果
 scoreboard objectives add RestoreItem trigger {"text":"リスト・アイテム処理選択"}
 scoreboard objectives add SuspiciousPowderTime dummy {"text":"怪しい粉継続秒数"}
 scoreboard objectives add SuspiciousPowderToken dummy {"text":"怪しい粉消費MP量"}
-
-###バースト ボスバー
-bossbar add skill:burst {"translate":"バーストゲージ","italic":true,"bold":true}
-bossbar set skill:burst color white
-bossbar set skill:burst visible false
-bossbar set skill:burst style notched_6
 
 ###乱数初期化
 summon minecraft:area_effect_cloud ~ ~ ~ {Age:0,WaitTime:1,ReapplicationDelay:0,Duration:0,Tags:[Initialized]}

--- a/data/player/function/burst/add.mcfunction
+++ b/data/player/function/burst/add.mcfunction
@@ -7,5 +7,7 @@ scoreboard players operation @s Burst += _ Burst
 execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID
 function player:burst/bar/set with storage tusb_player: burst
 
+scoreboard players set @s BurstTimer 20
+
 # 経験値バーリセット
 function player:mp_bar/set

--- a/data/player/function/burst/add.mcfunction
+++ b/data/player/function/burst/add.mcfunction
@@ -1,0 +1,11 @@
+#> player:burst/add
+
+scoreboard players operation _ Burst = @s XP
+scoreboard players operation _ Burst -= @s BeforeXP
+scoreboard players operation @s Burst += _ Burst
+
+execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID
+function player:burst/bar/set with storage tusb_player: burst
+
+# 経験値バーリセット
+function player:mp_bar/set

--- a/data/player/function/burst/add.mcfunction
+++ b/data/player/function/burst/add.mcfunction
@@ -4,8 +4,7 @@ scoreboard players operation _ Burst = @s XP
 scoreboard players operation _ Burst -= @s BeforeXP
 scoreboard players operation @s Burst += _ Burst
 
-execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID
-function player:burst/bar/set with storage tusb_player: burst
+function player:burst/bar/set
 
 scoreboard players set @s BurstTimer 20
 

--- a/data/player/function/burst/bar/common.mcfunction
+++ b/data/player/function/burst/bar/common.mcfunction
@@ -1,0 +1,3 @@
+#> player:burst/bar/common
+
+execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID

--- a/data/player/function/burst/bar/init.mcfunction
+++ b/data/player/function/burst/bar/init.mcfunction
@@ -1,0 +1,10 @@
+#> player:burst/bar/init
+
+# 個人バースト ボスバー作成
+$bossbar remove burst:$(id)
+$bossbar add burst:$(id) {"translate":"バーストゲージ","italic":true,"bold":true}
+$bossbar set burst:$(id) color white
+$bossbar set burst:$(id) visible false
+$bossbar set burst:$(id) style notched_6
+$bossbar set burst:$(id) max 100
+$bossbar set burst:$(id) players @s

--- a/data/player/function/burst/bar/init.mcfunction
+++ b/data/player/function/burst/bar/init.mcfunction
@@ -1,10 +1,5 @@
 #> player:burst/bar/init
+# バーストゲージの初期化
 
-# 個人バースト ボスバー作成
-$bossbar remove burst:$(id)
-$bossbar add burst:$(id) {"translate":"バーストゲージ","italic":true,"bold":true}
-$bossbar set burst:$(id) color white
-$bossbar set burst:$(id) visible false
-$bossbar set burst:$(id) style notched_6
-$bossbar set burst:$(id) max 100
-$bossbar set burst:$(id) players @s
+function player:burst/bar/common
+function player:burst/bar/macro/init with storage tusb_player: burst

--- a/data/player/function/burst/bar/macro/init.mcfunction
+++ b/data/player/function/burst/bar/macro/init.mcfunction
@@ -1,0 +1,10 @@
+#> player:burst/bar/macro/init
+
+# 個人バースト ボスバー作成
+$bossbar remove burst:$(id)
+$bossbar add burst:$(id) {"translate":"バーストゲージ","italic":true,"bold":true}
+$bossbar set burst:$(id) color white
+$bossbar set burst:$(id) visible false
+$bossbar set burst:$(id) style notched_6
+$bossbar set burst:$(id) max 100
+$bossbar set burst:$(id) players @s

--- a/data/player/function/burst/bar/macro/set.mcfunction
+++ b/data/player/function/burst/bar/macro/set.mcfunction
@@ -1,0 +1,7 @@
+#> player:burst/bar/macro/set
+
+$execute store result bossbar burst:$(id) value run scoreboard players get @s Burst
+
+# 表示
+$execute if score @s Burst matches 1.. run bossbar set burst:$(id) visible true
+$execute if score @s Burst matches ..0 run bossbar set burst:$(id) visible false

--- a/data/player/function/burst/bar/macro/warn.mcfunction
+++ b/data/player/function/burst/bar/macro/warn.mcfunction
@@ -1,0 +1,4 @@
+#> player:burst/bar/macro/warn
+
+$execute if score @s BurstTimer matches 1..5 run bossbar set burst:$(id) color red
+$execute unless score @s BurstTimer matches 1..5 run bossbar set burst:$(id) color white

--- a/data/player/function/burst/bar/set.mcfunction
+++ b/data/player/function/burst/bar/set.mcfunction
@@ -1,0 +1,7 @@
+#> player:burst/bar/set
+
+$execute store result bossbar burst:$(id) value run scoreboard players get @s Burst
+
+# 表示
+$execute if score @s Burst matches 1.. run bossbar set burst:$(id) visible true
+$execute if score @s Burst matches ..0 run bossbar set burst:$(id) visible false

--- a/data/player/function/burst/bar/set.mcfunction
+++ b/data/player/function/burst/bar/set.mcfunction
@@ -1,7 +1,5 @@
 #> player:burst/bar/set
+# 現在のバーストポイントをゲージに反映する
 
-$execute store result bossbar burst:$(id) value run scoreboard players get @s Burst
-
-# 表示
-$execute if score @s Burst matches 1.. run bossbar set burst:$(id) visible true
-$execute if score @s Burst matches ..0 run bossbar set burst:$(id) visible false
+function player:burst/bar/common
+function player:burst/bar/macro/set with storage tusb_player: burst

--- a/data/player/function/burst/bar/warn.mcfunction
+++ b/data/player/function/burst/bar/warn.mcfunction
@@ -1,0 +1,4 @@
+#> player:burst/bar/warn
+
+$execute if score @s BurstTimer matches 1..5 run bossbar set burst:$(id) color red
+$execute unless score @s BurstTimer matches 1..5 run bossbar set burst:$(id) color white

--- a/data/player/function/burst/bar/warn.mcfunction
+++ b/data/player/function/burst/bar/warn.mcfunction
@@ -1,4 +1,5 @@
 #> player:burst/bar/warn
+# バーストゲージ消失前演出
 
-$execute if score @s BurstTimer matches 1..5 run bossbar set burst:$(id) color red
-$execute unless score @s BurstTimer matches 1..5 run bossbar set burst:$(id) color white
+function player:burst/bar/common
+function player:burst/bar/macro/warn with storage tusb_player: burst

--- a/data/player/function/burst/maintain.mcfunction
+++ b/data/player/function/burst/maintain.mcfunction
@@ -1,0 +1,12 @@
+#> player:burst/maintain
+
+execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID
+
+scoreboard players remove @s BurstTimer 1
+
+function player:burst/bar/warn with storage tusb_player: burst
+
+execute if score @s BurstTimer matches 1.. run return 1
+
+scoreboard players set @s Burst 0
+function player:burst/bar/set with storage tusb_player: burst

--- a/data/player/function/burst/maintain.mcfunction
+++ b/data/player/function/burst/maintain.mcfunction
@@ -1,12 +1,10 @@
 #> player:burst/maintain
 
-execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID
-
 scoreboard players remove @s BurstTimer 1
 
-function player:burst/bar/warn with storage tusb_player: burst
+function player:burst/bar/warn
 
 execute if score @s BurstTimer matches 1.. run return 1
 
 scoreboard players set @s Burst 0
-function player:burst/bar/set with storage tusb_player: burst
+function player:burst/bar/set

--- a/data/player/function/burst/orb.mcfunction
+++ b/data/player/function/burst/orb.mcfunction
@@ -1,0 +1,6 @@
+#> player:burst/orb
+
+function settings:player/burst/add
+
+summon experience_orb ~ ~ ~ {Tags:[BurstOrb]}
+execute store result entity @n[type=experience_orb,tag=BurstOrb,distance=0] Value short 1 run scoreboard players get _ Burst

--- a/data/player/function/initialize.mcfunction
+++ b/data/player/function/initialize.mcfunction
@@ -24,5 +24,4 @@ team join Friendly
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SkillShortcut set value [{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"}]
 
 # バースト初期化
-execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID
-function player:burst/bar/init with storage tusb_player: burst
+function player:burst/bar/init

--- a/data/player/function/initialize.mcfunction
+++ b/data/player/function/initialize.mcfunction
@@ -22,3 +22,7 @@ team join Friendly
 
 #スキルショートカット
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SkillShortcut set value [{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"},{Skill:"<未設定>"}]
+
+# バースト初期化
+execute store result storage tusb_player: burst.id int 1 run scoreboard players get @s OhMyDatID
+function player:burst/bar/init with storage tusb_player: burst

--- a/data/player/function/mp_bar/set.mcfunction
+++ b/data/player/function/mp_bar/set.mcfunction
@@ -7,6 +7,9 @@ scoreboard players operation _ MP *= _ _
 scoreboard players operation _ MP /= @s MPMax
 scoreboard players operation _ MP < _ _
 
+# 表示経験値量を保存
+scoreboard players operation @s BeforeXP = _ MP
+
 #経験値バーに表示
 experience add @s -2147483648 levels
 experience add @s 40 levels

--- a/data/player/function/one_second.mcfunction
+++ b/data/player/function/one_second.mcfunction
@@ -16,3 +16,6 @@ execute if entity @s[scores={VirusCount=1..}] run function effect:virus/tick
 
 # 祈り表示
 execute if entity @s[scores={Job=1..},tag=Pray] run function player:pray
+
+# バースト維持
+execute if score @s BurstTimer matches 1.. run function player:burst/maintain

--- a/data/player/function/tick.mcfunction
+++ b/data/player/function/tick.mcfunction
@@ -19,6 +19,8 @@ execute if entity @s[scores={Age=1..},predicate=entity:player] if block ^ ^ ^ #b
 ### 特殊床
 execute if entity @s[predicate=entity:player] if block ~ ~-2 ~ #block:unique_floors run function block:unique_floor/fork
 
+execute if score @s BeforeXP < @s XP run function player:burst/add
+
 ### トリガー
 execute if entity @s[scores={UseBow=1..}] run function player:trigger/use/bow
 execute if entity @s[scores={UseCrossbow=1..}] run function player:trigger/use/crossbow

--- a/data/player/function/trigger/death.mcfunction
+++ b/data/player/function/trigger/death.mcfunction
@@ -29,6 +29,10 @@ execute if block ~ ~-2 ~ minecraft:nether_wart_block if entity @s[nbt={OnGround:
 execute if score @s FreezeTimer matches 0.. run function effect:freeze/cure
 function skill:act/white_mage/clear/cure/level4
 
+# バーストリセット
+scoreboard players set @s Burst 0
+function player:burst/bar/set
+
 ## 死亡トリガーリセット
 execute store result score @s Hunger run data get entity @s foodLevel
 scoreboard players reset @s Deaths

--- a/data/settings/function/player/burst/add.mcfunction
+++ b/data/settings/function/player/burst/add.mcfunction
@@ -1,4 +1,4 @@
-
+#> settings:player/burst/add
 ###レベルごとに増加量が異なる
 
 execute if score @s Level matches ..30 run scoreboard players set _ Burst 15


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-374
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
バーストゲージの仕組みを変更しました。
モブを倒したときに出てくる経験値オーブでバーストを溜めることができるようになります。
バーストゲージはプレイヤーごとに用意される。
バーストゲージの減少は1秒に1ずつではなく、バーストゲージの変化がなくなってから一定時間がたったら0になる。

## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* Mobが死亡時に経験値オーブを落とすように変更
* 経験値オーブを取得するとバーストゲージが増える
* バーストゲージの変化がない状態が一定時間経過すると0になる

## やってないこと<!-- なかったらこの項目を削除してください -->
<!-- このPR内でやっていないことやTODO等の残タスクを書く -->
* このバーストゲージの使い道

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
ただの経験値オーブでも大丈夫ですが、`BurstOrb`タグが必要です。

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
