### PR TITLE
白魔導士新スキル：ソルフレアの追加

### DIFF
--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -142,7 +142,8 @@ scoreboard objectives add KasapRatio dummy {"text":"ルカナントラップダ�
 scoreboard objectives add Decelerate dummy {"text":"ボミオストラップ継続秒数"}
 #白魔導士
 scoreboard objectives add HaloBound dummy {"text":"ヘイローバウンド演出カウント"}
-scoreboard objectives add SolFlare dummy {"text":"ソルフレアチャージ"}
+scoreboard objectives add SolFlare dummy {"text":"ソルフレアカウント"}
+scoreboard objectives add SolFlareCharge dummy {"text":"ソルフレアチャージ"}
 #黒魔導士
 scoreboard objectives add EclipseRadius dummy {"text":"エクリプスフレイム半径"}
 scoreboard objectives add LightningBlow dummy {"text":"ライトニングブロー威力"}

--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -142,6 +142,7 @@ scoreboard objectives add KasapRatio dummy {"text":"ルカナントラップダ�
 scoreboard objectives add Decelerate dummy {"text":"ボミオストラップ継続秒数"}
 #白魔導士
 scoreboard objectives add HaloBound dummy {"text":"ヘイローバウンド演出カウント"}
+scoreboard objectives add SolFlare dummy {"text":"ソルフレアチャージ"}
 #黒魔導士
 scoreboard objectives add EclipseRadius dummy {"text":"エクリプスフレイム半径"}
 scoreboard objectives add LightningBlow dummy {"text":"ライトニングブロー威力"}

--- a/data/main/predicate/weather/is_sunny.json
+++ b/data/main/predicate/weather/is_sunny.json
@@ -1,0 +1,5 @@
+{
+  "condition": "weather_check",
+  "raining": false,
+  "thundering": false
+}

--- a/data/makeup/function/skill/act/white_mage/sol_flare/charge.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/sol_flare/charge.mcfunction
@@ -1,0 +1,5 @@
+#> makeup:skill/act/white_mage/sol_flare/sol_flare/charge
+#
+# ソルフレア チャージ演出
+particle minecraft:enchant ~ ~1 ~ 0.5 1 0.5 1 20
+playsound entity.zombie_villager.converted player @a ~ ~ ~ 1 1.78

--- a/data/makeup/function/skill/act/white_mage/sol_flare/emission0.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/sol_flare/emission0.mcfunction
@@ -1,0 +1,48 @@
+#> makeup:skill/act/white_mage/sol_flare/emission0
+#
+# ソルフレア放射演出 0~2.5s
+
+# 魔法陣を作ってそこから光が降ってくる感じ
+# 太陽十字
+particle minecraft:flame ^0 ^3 ^-2 0 0 0 0 1
+particle minecraft:flame ^0.61803 ^3 ^-1.90211 0 0 0 0 1
+particle minecraft:flame ^1.17557 ^3 ^-1.61803 0 0 0 0 1
+particle minecraft:flame ^1.61803 ^3 ^-1.17557 0 0 0 0 1
+particle minecraft:flame ^1.90211 ^3 ^-0.61803 0 0 0 0 1
+particle minecraft:flame ^2 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^1.90211 ^3 ^0.61803 0 0 0 0 1
+particle minecraft:flame ^1.61803 ^3 ^1.17557 0 0 0 0 1
+particle minecraft:flame ^1.17557 ^3 ^1.61803 0 0 0 0 1
+particle minecraft:flame ^0.61803 ^3 ^1.90211 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^2 0 0 0 0 1
+particle minecraft:flame ^-0.61803 ^3 ^1.90211 0 0 0 0 1
+particle minecraft:flame ^-1.17557 ^3 ^1.61803 0 0 0 0 1
+particle minecraft:flame ^-1.61803 ^3 ^1.17557 0 0 0 0 1
+particle minecraft:flame ^-1.90211 ^3 ^0.61803 0 0 0 0 1
+particle minecraft:flame ^-2 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^-1.90211 ^3 ^-0.61803 0 0 0 0 1
+particle minecraft:flame ^-1.61803 ^3 ^-1.17557 0 0 0 0 1
+particle minecraft:flame ^-1.17557 ^3 ^-1.61803 0 0 0 0 1
+particle minecraft:flame ^-0.61803 ^3 ^-1.90211 0 0 0 0 1
+particle minecraft:flame ^-1.6 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^-1.2 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^-0.8 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^-0.4 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^0.4 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^0.8 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^1.2 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^1.6 ^3 ^0 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^-1.6 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^-1.2 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^-0.8 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^-0.4 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^0.4 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^0.8 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^1.2 0 0 0 0 1
+particle minecraft:flame ^0 ^3 ^1.6 0 0 0 0 1
+# 柱？
+particle minecraft:end_rod ^ ^ ^ 1 1 1 0 10 force @a
+particle minecraft:end_rod ^ ^ ^ 1 1 1 1 5 force @a
+
+playsound minecraft:item.firecharge.use player @a ~ ~ ~ 1 1

--- a/data/makeup/function/skill/act/white_mage/sol_flare/emission1.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/sol_flare/emission1.mcfunction
@@ -1,0 +1,56 @@
+#> makeup:skill/act/white_mage/sol_flare/emission1
+#
+# ソルフレア放射演出 2.5~5s
+
+# 上に太陽を表す図形の魔法陣を作ってそこから光が降ってくる感じ
+# 太陽十字
+particle minecraft:flame ^0 ^4 ^-3 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^-2.5 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^-2 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^-1.5 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^-1 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^-0.5 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^0.5 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^1 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^1.5 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^2 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^2.5 0 0 0 0 1
+particle minecraft:flame ^0 ^4 ^3 0 0 0 0 1
+particle minecraft:flame ^0.77646 ^4 ^-2.89778 0 0 0 0 1
+particle minecraft:flame ^1.5 ^4 ^-2.59808 0 0 0 0 1
+particle minecraft:flame ^2.12132 ^4 ^-2.12132 0 0 0 0 1
+particle minecraft:flame ^2.59808 ^4 ^-1.5 0 0 0 0 1
+particle minecraft:flame ^2.89778 ^4 ^-0.77646 0 0 0 0 1
+particle minecraft:flame ^3 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^2.89778 ^4 ^0.77646 0 0 0 0 1
+particle minecraft:flame ^2.59808 ^4 ^1.5 0 0 0 0 1
+particle minecraft:flame ^2.12132 ^4 ^2.12132 0 0 0 0 1
+particle minecraft:flame ^1.5 ^4 ^2.59808 0 0 0 0 1
+particle minecraft:flame ^0.77646 ^4 ^2.89778 0 0 0 0 1
+particle minecraft:flame ^-0.77646 ^4 ^2.89778 0 0 0 0 1
+particle minecraft:flame ^-1.5 ^4 ^2.59808 0 0 0 0 1
+particle minecraft:flame ^-2.12132 ^4 ^2.12132 0 0 0 0 1
+particle minecraft:flame ^-2.59808 ^4 ^1.5 0 0 0 0 1
+particle minecraft:flame ^-2.89778 ^4 ^0.77646 0 0 0 0 1
+particle minecraft:flame ^-3 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^-2.89778 ^4 ^-0.77646 0 0 0 0 1
+particle minecraft:flame ^-2.59808 ^4 ^-1.5 0 0 0 0 1
+particle minecraft:flame ^-2.12132 ^4 ^-2.12132 0 0 0 0 1
+particle minecraft:flame ^-1.5 ^4 ^-2.59808 0 0 0 0 1
+particle minecraft:flame ^-0.77646 ^4 ^-2.89778 0 0 0 0 1
+particle minecraft:flame ^-2.5 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^-2 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^-1.5 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^-1 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^-0.5 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^0.5 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^1 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^1.5 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^2 ^4 ^0 0 0 0 0 1
+particle minecraft:flame ^2.5 ^4 ^0 0 0 0 0 1
+# 柱？
+particle minecraft:end_rod ^ ^ ^ 2 2 2 0 50 force @a
+particle minecraft:end_rod ^ ^ ^ 1 1 1 1 5 force @a
+
+playsound minecraft:item.firecharge.use player @a ~ ~ ~ 1 1

--- a/data/makeup/function/skill/act/white_mage/sol_flare/emission2.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/sol_flare/emission2.mcfunction
@@ -1,0 +1,94 @@
+#> makeup:skill/act/white_mage/sol_flare/emission2
+#
+# ソルフレア放射演出 5~10s
+
+# 太陽十字
+particle minecraft:flame ^0 ^5 ^-4 0 0 0 0 1
+particle minecraft:flame ^0.78036 ^5 ^-3.92314 0 0 0 0 1
+particle minecraft:flame ^1.53073 ^5 ^-3.69552 0 0 0 0 1
+particle minecraft:flame ^2.22228 ^5 ^-3.32588 0 0 0 0 1
+particle minecraft:flame ^2.82843 ^5 ^-2.82843 0 0 0 0 1
+particle minecraft:flame ^3.32588 ^5 ^-2.22228 0 0 0 0 1
+particle minecraft:flame ^3.69552 ^5 ^-1.53073 0 0 0 0 1
+particle minecraft:flame ^3.92314 ^5 ^-0.78036 0 0 0 0 1
+particle minecraft:flame ^4 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^3.92314 ^5 ^0.78036 0 0 0 0 1
+particle minecraft:flame ^3.69552 ^5 ^1.53073 0 0 0 0 1
+particle minecraft:flame ^3.32588 ^5 ^2.22228 0 0 0 0 1
+particle minecraft:flame ^2.82843 ^5 ^2.82843 0 0 0 0 1
+particle minecraft:flame ^2.22228 ^5 ^3.32588 0 0 0 0 1
+particle minecraft:flame ^1.53073 ^5 ^3.69552 0 0 0 0 1
+particle minecraft:flame ^0.78036 ^5 ^3.92314 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^4 0 0 0 0 1
+particle minecraft:flame ^-0.78036 ^5 ^3.92314 0 0 0 0 1
+particle minecraft:flame ^-1.53073 ^5 ^3.69552 0 0 0 0 1
+particle minecraft:flame ^-2.22228 ^5 ^3.32588 0 0 0 0 1
+particle minecraft:flame ^-2.82843 ^5 ^2.82843 0 0 0 0 1
+particle minecraft:flame ^-3.32588 ^5 ^2.22228 0 0 0 0 1
+particle minecraft:flame ^-3.69552 ^5 ^1.53073 0 0 0 0 1
+particle minecraft:flame ^-3.92314 ^5 ^0.78036 0 0 0 0 1
+particle minecraft:flame ^-4 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^-3.92314 ^5 ^-0.78036 0 0 0 0 1
+particle minecraft:flame ^-3.69552 ^5 ^-1.53073 0 0 0 0 1
+particle minecraft:flame ^-3.32588 ^5 ^-2.22228 0 0 0 0 1
+particle minecraft:flame ^-2.82843 ^5 ^-2.82843 0 0 0 0 1
+particle minecraft:flame ^-2.22228 ^5 ^-3.32588 0 0 0 0 1
+particle minecraft:flame ^-1.53073 ^5 ^-3.69552 0 0 0 0 1
+particle minecraft:flame ^-0.78036 ^5 ^-3.92314 0 0 0 0 1
+particle minecraft:flame ^-3.42857 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^-2.85714 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^-2.28571 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^-1.71429 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^-1.14286 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^-0.57143 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^0.57143 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^1.14286 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^1.71429 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^2.28571 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^2.85714 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^3.42857 ^5 ^0 0 0 0 0 1
+particle minecraft:flame ^-2.41714 ^5 ^-2.41714 0 0 0 0 1
+particle minecraft:flame ^-2.01429 ^5 ^-2.01429 0 0 0 0 1
+particle minecraft:flame ^-1.61143 ^5 ^-1.61143 0 0 0 0 1
+particle minecraft:flame ^-1.20857 ^5 ^-1.20857 0 0 0 0 1
+particle minecraft:flame ^-0.80571 ^5 ^-0.80571 0 0 0 0 1
+particle minecraft:flame ^-0.40286 ^5 ^-0.40286 0 0 0 0 1
+particle minecraft:flame ^0.40286 ^5 ^0.40286 0 0 0 0 1
+particle minecraft:flame ^0.80571 ^5 ^0.80571 0 0 0 0 1
+particle minecraft:flame ^1.20857 ^5 ^1.20857 0 0 0 0 1
+particle minecraft:flame ^1.61143 ^5 ^1.61143 0 0 0 0 1
+particle minecraft:flame ^2.01429 ^5 ^2.01429 0 0 0 0 1
+particle minecraft:flame ^2.41714 ^5 ^2.41714 0 0 0 0 1
+particle minecraft:flame ^2.41714 ^5 ^-2.41714 0 0 0 0 1
+particle minecraft:flame ^2.01429 ^5 ^-2.01429 0 0 0 0 1
+particle minecraft:flame ^1.61143 ^5 ^-1.61143 0 0 0 0 1
+particle minecraft:flame ^1.20857 ^5 ^-1.20857 0 0 0 0 1
+particle minecraft:flame ^0.80571 ^5 ^-0.80571 0 0 0 0 1
+particle minecraft:flame ^0.40286 ^5 ^-0.40286 0 0 0 0 1
+particle minecraft:flame ^-0.40286 ^5 ^0.40286 0 0 0 0 1
+particle minecraft:flame ^-0.80571 ^5 ^0.80571 0 0 0 0 1
+particle minecraft:flame ^-1.20857 ^5 ^1.20857 0 0 0 0 1
+particle minecraft:flame ^-1.61143 ^5 ^1.61143 0 0 0 0 1
+particle minecraft:flame ^-2.01429 ^5 ^2.01429 0 0 0 0 1
+particle minecraft:flame ^-2.41714 ^5 ^2.41714 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^-3.42857 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^-2.85714 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^-2.28571 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^-1.71429 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^-1.14286 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^-0.57143 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^0.57143 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^1.14286 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^1.71429 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^2.28571 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^2.85714 0 0 0 0 1
+particle minecraft:flame ^0 ^5 ^3.42857 0 0 0 0 1
+# 柱？
+particle minecraft:end_rod ^ ^ ^ 3 3 3 0 50 force @a
+particle minecraft:end_rod ^ ^ ^ 3 3 3 0 50 force @a[tag=ShowParticles]
+particle minecraft:end_rod ^ ^ ^ 1 1 1 1 10 force @a
+
+playsound minecraft:item.firecharge.use player @a ~ ~ ~ 1 1
+playsound minecraft:block.beacon.power_select player @a ~ ~ ~ 1 2
+playsound block.amethyst_block.chime player @a ~ ~ ~ 1 1

--- a/data/makeup/function/skill/act/white_mage/sol_flare/fail.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/sol_flare/fail.mcfunction
@@ -1,0 +1,5 @@
+#> makeup:skill/act/white_mage/sol_flare/fail
+#
+# ソルフレア 失敗演出
+particle minecraft:poof ~ ~ ~ 1 1 1 0 10 force
+playsound block.fire.extinguish player @s

--- a/data/makeup/function/skill/act/white_mage/sol_flare/tick1.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/sol_flare/tick1.mcfunction
@@ -1,0 +1,5 @@
+#> makeup:skill/act/white_mage/sol_flare/tick1
+#
+# ソルフレア チャージ1→2 演出
+particle minecraft:flame ~ ~0.5 ~ 0.5 1 0.5 0 20
+playsound entity.zombie_villager.converted player @a ~ ~ ~ 1 1.89

--- a/data/makeup/function/skill/act/white_mage/sol_flare/tick2.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/sol_flare/tick2.mcfunction
@@ -1,0 +1,5 @@
+#> makeup:skill/act/white_mage/sol_flare/tick2
+#
+# ソルフレア チャージ2→3 演出
+particle minecraft:flame ~ ~0.5 ~ 1.5 1.5 1.5 0 40
+playsound entity.zombie_villager.converted player @a ~ ~ ~ 1 2

--- a/data/skill/function/act/white_mage/sol_flare/act0.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/act0.mcfunction
@@ -1,0 +1,5 @@
+#> skill:act/white_mage/sol_flare/act0
+#
+# ソルフレア分岐
+execute unless score @s SolFlareCharge matches 0.. run return run function skill:act/white_mage/sol_flare/charge
+execute if score @s SolFlareCharge matches 1.. run function skill:act/white_mage/sol_flare/fork

--- a/data/skill/function/act/white_mage/sol_flare/charge.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/charge.mcfunction
@@ -3,9 +3,9 @@
 # ソルフレア チャージ開始
 scoreboard players set @s SolFlareCharge 0
 
-execute if score _ Level matches 1 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:1}].Damage
-execute if score _ Level matches 2 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:2}].Damage
-execute if score _ Level matches 3 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:3}].Damage
+execute if score _ Level matches 1 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:1}].Damage.physical
+execute if score _ Level matches 2 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:2}].Damage.physical
+execute if score _ Level matches 3 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:3}].Damage.physical
 
 # チャージではMPを消費しない
 scoreboard players set _ MP 0

--- a/data/skill/function/act/white_mage/sol_flare/charge.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/charge.mcfunction
@@ -1,0 +1,19 @@
+#> skill:act/white_mage/sol_flare/charge
+#
+# ソルフレア チャージ開始
+scoreboard players set @s SolFlareCharge 0
+
+execute if score _ Level matches 1 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:1}].Damage
+execute if score _ Level matches 2 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:2}].Damage
+execute if score _ Level matches 3 store result score @s SolFlare run data get storage skill: Data.WhiteMage[{Name:"ソルフレア",Level:3}].Damage
+
+# チャージではMPを消費しない
+scoreboard players set _ MP 0
+
+# 移動速度を半減させる UUIDはSolFlareを16進数化したもの
+attribute @s minecraft:movement_speed modifier add 536f-6c4-66c-617-265 -0.5 add_multiplied_total
+
+# 演出
+function makeup:skill/act/white_mage/sol_flare/charge
+
+

--- a/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
@@ -4,6 +4,8 @@
 scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
+# ストレージをリセット
+data remove storage skill: damage.physical
 # ダメージ
 execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function skill:damage/apply/

--- a/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ダメージ
-execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
+execute store result storage skill: damage.magic int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function skill:damage/apply/
 # 火だるまを付与
 execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function effect:enemy_debuff/burn/apply

--- a/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ダメージ
-execute store result storage skill: damage.magic int 1 run scoreboard players get @s SolFlare
+execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function skill:damage/apply/
 # 火だるまを付与
 execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function effect:enemy_debuff/burn/apply

--- a/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ストレージをリセット
-data remove storage skill: damage.physical
+data remove storage skill: damage
 # ダメージ
 execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function skill:damage/apply/

--- a/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
@@ -7,6 +7,8 @@ attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 # ダメージ
 execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function skill:damage/apply/
+# 火だるまを付与
+execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function effect:enemy_debuff/burn/apply
 
 # 演出
 execute positioned ^ ^ ^3 rotated 0 0 run function makeup:skill/act/white_mage/sol_flare/emission0

--- a/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission0.mcfunction
@@ -1,0 +1,12 @@
+#> skill:act/white_mage/sol_flare/emission0
+#
+# ソルフレア放射 0~2.5s
+scoreboard players reset @s SolFlareCharge
+attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
+
+# ダメージ
+execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
+execute positioned ^ ^ ^3 rotated 0 0 as @e[tag=Enemy,distance=..3] run function skill:damage/apply/
+
+# 演出
+execute positioned ^ ^ ^3 rotated 0 0 run function makeup:skill/act/white_mage/sol_flare/emission0

--- a/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ストレージをリセット
-data remove storage skill: damage.physical
+data remove storage skill: damage
 # ダメージ
 execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function skill:damage/apply/

--- a/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
@@ -1,0 +1,12 @@
+#> skill:act/white_mage/sol_flare/emission1
+#
+# ソルフレア放射 2.5~5s
+scoreboard players reset @s SolFlareCharge
+attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
+
+# ダメージ
+execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
+execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function skill:damage/apply/
+
+# 演出
+execute positioned ^ ^ ^4 rotated 0 0 run function makeup:skill/act/white_mage/sol_flare/emission1

--- a/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
@@ -7,6 +7,8 @@ attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 # ダメージ
 execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function skill:damage/apply/
+# 火だるまを付与
+execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function effect:enemy_debuff/burn/apply
 
 # 演出
 execute positioned ^ ^ ^4 rotated 0 0 run function makeup:skill/act/white_mage/sol_flare/emission1

--- a/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ダメージ
-execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
+execute store result storage skill: damage.magic int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function skill:damage/apply/
 # 火だるまを付与
 execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function effect:enemy_debuff/burn/apply

--- a/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
@@ -4,6 +4,8 @@
 scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
+# ストレージをリセット
+data remove storage skill: damage.physical
 # ダメージ
 execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function skill:damage/apply/

--- a/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission1.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ダメージ
-execute store result storage skill: damage.magic int 1 run scoreboard players get @s SolFlare
+execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function skill:damage/apply/
 # 火だるまを付与
 execute positioned ^ ^ ^4 rotated 0 0 as @e[tag=Enemy,distance=..4] run function effect:enemy_debuff/burn/apply

--- a/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
@@ -1,0 +1,12 @@
+#> skill:act/white_mage/sol_flare/emission2
+#
+# ソルフレア放射 5~10s
+scoreboard players reset @s SolFlareCharge
+attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
+
+# ダメージ
+execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
+execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function skill:damage/apply/
+
+# 演出
+execute positioned ^ ^ ^5 rotated 0 0 run function makeup:skill/act/white_mage/sol_flare/emission2

--- a/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
@@ -4,6 +4,8 @@
 scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
+# ストレージをリセット
+data remove storage skill: damage.physical
 # ダメージ
 execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function skill:damage/apply/

--- a/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ダメージ
-execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
+execute store result storage skill: damage.magic int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function skill:damage/apply/
 # 火だるまを付与
 execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function effect:enemy_debuff/burn/apply

--- a/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ストレージをリセット
-data remove storage skill: damage.physical
+data remove storage skill: damage
 # ダメージ
 execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function skill:damage/apply/

--- a/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
@@ -5,7 +5,7 @@ scoreboard players reset @s SolFlareCharge
 attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 
 # ダメージ
-execute store result storage skill: damage.magic int 1 run scoreboard players get @s SolFlare
+execute store result storage skill: damage.physical int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function skill:damage/apply/
 # 火だるまを付与
 execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function effect:enemy_debuff/burn/apply

--- a/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/emission2.mcfunction
@@ -7,6 +7,8 @@ attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
 # ダメージ
 execute store result storage skill: damage int 1 run scoreboard players get @s SolFlare
 execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function skill:damage/apply/
+# 火だるまを付与
+execute positioned ^ ^ ^5 rotated 0 0 as @e[tag=Enemy,distance=..5] run function effect:enemy_debuff/burn/apply
 
 # 演出
 execute positioned ^ ^ ^5 rotated 0 0 run function makeup:skill/act/white_mage/sol_flare/emission2

--- a/data/skill/function/act/white_mage/sol_flare/fail.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/fail.mcfunction
@@ -1,0 +1,8 @@
+#> skill:act/white_mage/sol_flare/fail
+#
+# ソルフレア 失敗
+scoreboard players reset @s SolFlareCharge
+attribute @s minecraft:movement_speed modifier remove 536f-6c4-66c-617-265
+
+# 演出
+function makeup:skill/act/white_mage/sol_flare/fail

--- a/data/skill/function/act/white_mage/sol_flare/fork.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/fork.mcfunction
@@ -1,0 +1,8 @@
+#> skill:act/white_mage/sol_flare/fork
+#
+# ソルフレア放射 分岐
+
+# チャージ（SolFlareCharge）の値に応じて分岐
+execute if score @s SolFlareCharge matches 0..49 run return run function skill:act/white_mage/sol_flare/emission0
+execute if score @s SolFlareCharge matches 50..99 run return run function skill:act/white_mage/sol_flare/emission1
+execute if score @s SolFlareCharge matches 100.. run function skill:act/white_mage/sol_flare/emission2

--- a/data/skill/function/act/white_mage/sol_flare/tick.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/tick.mcfunction
@@ -1,0 +1,11 @@
+#> skill:act/white_mage/sol_flare/tick
+#
+# ソルフレア tick処理
+
+scoreboard players add @s SolFlareCharge 1
+# チャージしすぎたら失敗＋演出
+execute if score @s SolFlareCharge matches 200.. run function skill:act/white_mage/sol_flare/fail
+
+# 演出
+execute if score @s SolFlareCharge matches 50 run function makeup:skill/act/white_mage/sol_flare/tick1
+execute if score @s SolFlareCharge matches 100 run function makeup:skill/act/white_mage/sol_flare/tick2

--- a/data/skill/function/act/white_mage/sol_flare/tick.mcfunction
+++ b/data/skill/function/act/white_mage/sol_flare/tick.mcfunction
@@ -3,6 +3,11 @@
 # ソルフレア tick処理
 
 scoreboard players add @s SolFlareCharge 1
+# 晴れていて上にブロックがなければチャージ速度2倍
+data remove storage calc: SearchAbove
+execute store result storage calc: SearchAbove.Pos int 1 run data get entity @s Pos[1]
+execute if predicate main:weather/is_sunny run function calc:geometry/search_above/to_limit
+execute if data storage calc: {SearchAbove:{NothingAbove:1b}} run scoreboard players add @s SolFlareCharge 1
 # チャージしすぎたら失敗＋演出
 execute if score @s SolFlareCharge matches 200.. run function skill:act/white_mage/sol_flare/fail
 

--- a/data/skill/function/player_tick.mcfunction
+++ b/data/skill/function/player_tick.mcfunction
@@ -44,3 +44,7 @@ execute if entity @s[scores={BlastSpark=1..}] anchored eyes positioned ^ ^ ^-0.1
 
 # レーダーヴィジョン
 execute if entity @s[scores={RadarVision=1..}] run function skill:act/hunter/radar_vision/tick
+
+## 白魔導士
+# ソルフレア
+execute if score @s SolFlareCharge matches 0.. run function skill:act/white_mage/sol_flare/tick


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-802
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
白魔導士のスキル、ソルフレアを追加した。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
ソルフレアの追加
以下スペック
使用時にMPを消費せず、チャージを開始する。チャージ中は足が遅くなる。50tickで2段階目、100tickで3段階目になり、200tickで失敗処理が行われる。
攻撃範囲は視線の（チャージ範囲+2）マス先からdistance=..（チャージ範囲+2）で判定、演出もそれに合わせて変化する。

## レビュー観点<!-- なかったらこの項目を削除してください -->
<!-- - 想定通りに動作するか？ -->
<!-- - 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？ -->
MPの消費を0にしたことによる問題がないか。

## 補足<!-- なかったらこの項目を削除してください -->
<!-- 追加で伝えたいことがあれば -->
・Exportツールを使用してからレビューしてください。
・演出面がしっくりこないので、改善案があれば挙げてください。
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
