### PR TITLE
LootTableがないコンテナのloot_tableパスの保存方法を変更

### DIFF
--- a/data/item/advancement/generate_container_loot.json
+++ b/data/item/advancement/generate_container_loot.json
@@ -1,7 +1,7 @@
 {
   "criteria": {
     "requirement": {
-      "trigger": "minecraft:item_used_on_block",
+      "trigger": "minecraft:default_block_use",
       "conditions": {
         "location": [
           {

--- a/data/item/function/generate_container_loot/check_block/chest.mcfunction
+++ b/data/item/function/generate_container_loot/check_block/chest.mcfunction
@@ -1,10 +1,10 @@
 #> item:generate_container_loot/check_block/chest
 #ラージチェスト分岐
-execute if block ~ ~ ~ #item:containers[facing=north,type=right] positioned ~-1 ~ ~ if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
-execute if block ~ ~ ~ #item:containers[facing=north,type=left] positioned ~1 ~ ~ if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
-execute if block ~ ~ ~ #item:containers[facing=south,type=right] positioned ~1 ~ ~ if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
-execute if block ~ ~ ~ #item:containers[facing=south,type=left] positioned ~-1 ~ ~ if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
-execute if block ~ ~ ~ #item:containers[facing=east,type=right] positioned ~ ~ ~-1 if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
-execute if block ~ ~ ~ #item:containers[facing=east,type=left] positioned ~ ~ ~1 if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
-execute if block ~ ~ ~ #item:containers[facing=west,type=right] positioned ~ ~ ~1 if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
-execute if block ~ ~ ~ #item:containers[facing=west,type=left] positioned ~ ~ ~-1 if data block ~ ~ ~ Lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=north,type=right] positioned ~-1 ~ ~ if data block ~ ~ ~ lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=north,type=left] positioned ~1 ~ ~ if data block ~ ~ ~ lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=south,type=right] positioned ~1 ~ ~ if data block ~ ~ ~ lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=south,type=left] positioned ~-1 ~ ~ if data block ~ ~ ~ lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=east,type=right] positioned ~ ~ ~-1 if data block ~ ~ ~ lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=east,type=left] positioned ~ ~ ~1 if data block ~ ~ ~ lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=west,type=right] positioned ~ ~ ~1 if data block ~ ~ ~ lock run function item:generate_container_loot/loot/
+execute if block ~ ~ ~ #item:containers[facing=west,type=left] positioned ~ ~ ~-1 if data block ~ ~ ~ lock run function item:generate_container_loot/loot/

--- a/data/item/function/generate_container_loot/loot/.mcfunction
+++ b/data/item/function/generate_container_loot/loot/.mcfunction
@@ -2,6 +2,8 @@
 #ルートテーブルを適用
 execute if block ~ ~ ~ #item:lootable_containers if data block ~ ~ ~ LootTable run function item:generate_container_loot/loot/lootable
 execute unless block ~ ~ ~ #item:lootable_containers run function item:generate_container_loot/loot/not_lootable
+#空白用アイテムを削除
+data remove block ~ ~ ~ Items[{components:{"minecraft:custom_data":{container_dummy:true}}}]
 #演出
 execute if data block ~ ~ ~ lock.components."minecraft:custom_data".container_loot_table run function makeup:item/generate_container_loot
 #container_loot_tableがあるならlockを削除

--- a/data/item/function/generate_container_loot/loot/.mcfunction
+++ b/data/item/function/generate_container_loot/loot/.mcfunction
@@ -2,8 +2,7 @@
 #ルートテーブルを適用
 execute if block ~ ~ ~ #item:lootable_containers if data block ~ ~ ~ LootTable run function item:generate_container_loot/loot/lootable
 execute unless block ~ ~ ~ #item:lootable_containers run function item:generate_container_loot/loot/not_lootable
-#16文字以上ならLockを削除
-execute store result score _ _ run data get block ~ ~ ~ Lock
-execute if score _ _ matches 16.. run data remove block ~ ~ ~ Lock
 #演出
-execute if score _ _ matches 16.. run function makeup:item/generate_container_loot
+execute if data block ~ ~ ~ lock.components."minecraft:custom_data".container_loot_table run function makeup:item/generate_container_loot
+#container_loot_tableがあるならlockを削除
+execute if data block ~ ~ ~ lock.components."minecraft:custom_data".container_loot_table run data remove block ~ ~ ~ lock

--- a/data/item/function/generate_container_loot/loot/lootable.mcfunction
+++ b/data/item/function/generate_container_loot/loot/lootable.mcfunction
@@ -3,5 +3,6 @@
 data remove entity 0-0-0-0-3 DeathLootTable
 data modify entity 0-0-0-0-3 DeathLootTable set from block ~ ~ ~ LootTable
 data modify block ~ ~ ~ LootTable set value ""
+loot replace block ~ ~ ~ container.0 kill 0-0-0-0-3
 #コンテナ破壊処理
 execute if data block ~ ~ ~ Items[].components."minecraft:custom_data".BreakContainer run setblock ~ ~ ~ air destroy

--- a/data/item/function/generate_container_loot/loot/not_lootable.mcfunction
+++ b/data/item/function/generate_container_loot/loot/not_lootable.mcfunction
@@ -1,7 +1,7 @@
 #> item:generate_container_loot/loot/not_lootable
 #ItemsにLockのルートテーブルを適用する
 data remove entity 0-0-0-0-3 DeathLootTable
-data modify entity 0-0-0-0-3 DeathLootTable set from block ~ ~ ~ Lock
+data modify entity 0-0-0-0-3 DeathLootTable set from block ~ ~ ~ lock.components."minecraft:custom_data".container_loot_table
 execute in area:control_area run data remove block 2 2 2 Items
 execute in area:control_area run loot replace block 2 2 2 container.0 kill 0-0-0-0-3
 execute in area:control_area run data modify storage item: Items set from block 2 2 2 Items

--- a/data/item/function/generate_container_loot/search.mcfunction
+++ b/data/item/function/generate_container_loot/search.mcfunction
@@ -1,5 +1,5 @@
 #> item:generate_container_loot/search
 #前方を探索
 execute store result storage calc: SearchForward.Loop int 0.99999 run data get storage calc: SearchForward.Loop
-execute if block ^ ^ ^ #item:containers if data block ^ ^ ^ Lock store success storage calc: SearchForward.Loop int 0 run function item:generate_container_loot/check_block/
+execute if block ^ ^ ^ #item:containers if data block ^ ^ ^ lock store success storage calc: SearchForward.Loop int 0 run function item:generate_container_loot/check_block/
 execute unless data storage calc: SearchForward{Loop:0} positioned ^ ^ ^0.5 run function item:generate_container_loot/search


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-340
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
コンテナブロックの`Lock`タグが`lock`タグへ変更されたことに伴い、loot_tableパスの保存場所を変更。
ルートテーブルからルートされるアイテムに`air`が指定できなくなったため、空白マスを表現するためのアイテムを追加。また、そのアイテムを削除する処理を追加
その他、コンテナ生成に発生していたバグを修正。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
* lockタグ内にLootTableパスを保存するように変更
* コンテナの中身が生成されないバグを修正
* コンテナの生成処理が始まらないバグを修正
* `air`に頼らずに空白マスを生成できるようにアイテムを追加
## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
```mcfunction
give @p chest[item_name='{"translate":"固定チェスト","color":"#AFBC91","bold":true,"italic":false}',lore=['{"text":"デバッグルームTier1戦闘装備ラージチェスト"}','{"text":"tier1_combat_equipment_left"}'],container_loot={loot_table:"item:chest/debug_room/unique/tier1_combat_equipment_left"},lock={components:{"minecraft:custom_data":{container_loot_table:"item:chest/debug_room/unique/tier1_combat_equipment_left"}}}]
```
<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
