### PR TITLE
ケアルの一部SEが鳴らない問題を修正

### DIFF
--- a/data/makeup/function/skill/act/white_mage/cure/apply.mcfunction
+++ b/data/makeup/function/skill/act/white_mage/cure/apply.mcfunction
@@ -2,8 +2,9 @@
 #
 # ケアル発動演出
 
-playsound minecraft:entity.player.levelup player @a[distance=..16] ~ ~ ~ 1 1.4
-playsound minecraft:entity.player.levelup player @a[distance=..16] ~ ~ ~ 1 2
+# リソパの実装までplayerが使えないためmasterで据え置き
+playsound minecraft:entity.player.levelup master @a[distance=..16] ~ ~ ~ 1 1.4
+playsound minecraft:entity.player.levelup master @a[distance=..16] ~ ~ ~ 1 2
 playsound minecraft:block.note_block.chime player @a[distance=..16] ~ ~ ~ 1 1.2
 particle minecraft:heart ~ ~0.1 ~ 0.7 0.1 0.7 0 10 force
 particle minecraft:happy_villager ~ ~0.3 ~ 0.5 0.3 0.5 0 20 force


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
NO-ISSUE
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
minecraft:entity.player.levelupはサウンドソースがplayerの時正常に鳴らないため、リソパの対応まで一時的にmasterに戻す。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
ケアルのminecraft:entity.player.levelupのサウンドソースをplayer→masterに戻した。

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [x] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
