### PR TITLE
ブリッツマニューバの1.21.4移植

### DIFF
--- a/data/main/function/load_once.mcfunction
+++ b/data/main/function/load_once.mcfunction
@@ -153,7 +153,7 @@ scoreboard objectives add SolFlareCharge dummy {"text":"ソルフレアチャー
 #黒魔導士
 scoreboard objectives add EclipseRadius dummy {"text":"エクリプスフレイム半径"}
 scoreboard objectives add LightningBlow dummy {"text":"ライトニングブロー威力"}
-scoreboard objectives add BlitzManover dummy {"text":"ブリッツマニューバ残りtick数"}
+scoreboard objectives add BlitzManeuver dummy {"text":"ブリッツマニューバ残りtick数"}
 scoreboard objectives add RockNRoll dummy {"text":"ロックンロール残り推定時間"}
 scoreboard objectives add Sleepga dummy {"text":"スリプガ継続秒数"}
 scoreboard objectives add ManaRefresh dummy {"text":"マナリフレッシュ残りミリ秒＆レベル"}

--- a/data/makeup/function/skill/act/black_mage/blitz_maneuver/apply.mcfunction
+++ b/data/makeup/function/skill/act/black_mage/blitz_maneuver/apply.mcfunction
@@ -1,0 +1,9 @@
+#> makeup:skill/act/black_mage/blitz_maneuver/apply
+#
+# ブリッツマニューバ適用演出
+playsound minecraft:entity.wither.hurt player @a[distance=..16] ~ ~ ~ 1 2
+playsound minecraft:entity.skeleton_horse.death player @a[distance=..16] ~ ~ ~ 0.5 2
+playsound minecraft:item.totem.use player @a[distance=..16] ~ ~ ~ 0.5 1.4
+particle minecraft:dust_color_transition{from_color:[1.0,1.0,0.0],to_color:[0.0,1.0,0.0],scale:2} ~ ~0.2 ~ 2 0.2 0.2 1 40 force
+particle minecraft:dust_color_transition{from_color:[1.0,1.0,0.0],to_color:[0.0,1.0,0.0],scale:2} ~ ~0.2 ~ 0.2 0.2 2 1 40 force
+summon minecraft:area_effect_cloud ~ ~1 ~ {Particle:{type:item,item:{id:"minecraft:sunflower"}},ReapplicationDelay:40,Radius:1f,RadiusPerTick:0.5f,Duration:10}

--- a/data/makeup/function/skill/act/black_mage/blitz_maneuver/tick.mcfunction
+++ b/data/makeup/function/skill/act/black_mage/blitz_maneuver/tick.mcfunction
@@ -1,0 +1,5 @@
+#> makeup:skill/act/black_mage/blitz_maneuver/tick
+#
+# ブリッツマニューバ毎tick演出
+execute rotated as @e[limit=1,sort=random] rotated ~ 0 run particle minecraft:dust_color_transition{from_color:[1.0,1.0,0.0],to_color:[0.0,1.0,0.0],scale:1.5} ^ ^0.2 ^2.5 1 0 0 1 4 force @a[tag=ShowParticles]
+execute rotated as @e[limit=1,sort=random] rotated ~ 0 run particle minecraft:dust_color_transition{from_color:[1.0,1.0,0.0],to_color:[0.0,1.0,0.0],scale:1.5} ^ ^0.2 ^2.5 0 0 1 1 4 force @a[tag=ShowParticles]

--- a/data/makeup/function/skill/act/black_mage/blitz_maneuver/trigger.mcfunction
+++ b/data/makeup/function/skill/act/black_mage/blitz_maneuver/trigger.mcfunction
@@ -1,0 +1,10 @@
+#> makeup:skill/act/black_mage/blitz_maneuver/trigger
+#
+# ブリッツマニューバトリガー演出
+playsound minecraft:entity.firework_rocket.twinkle player @a[distance=..16] ~ ~ ~ 1 1
+playsound minecraft:entity.firework_rocket.twinkle player @a[distance=..16] ~ ~ ~ 1 1.4
+playsound minecraft:item.trident.riptide_3 player @a[distance=..16] ~ ~ ~ 1 1.1
+playsound minecraft:entity.lightning_bolt.thunder player @a[distance=..16] ~ ~ ~ 1 2
+execute as @e[limit=5,sort=random] rotated as @s rotated ~ 0 run particle minecraft:dust_color_transition{from_color:[0.75,0.75,1.0],to_color:[0.0,0.0,1.0],scale:2} ^ ^0.5 ^3 2 0 0 1 10 force
+execute as @e[limit=5,sort=random] rotated as @s rotated ~ 0 run particle minecraft:dust_color_transition{from_color:[0.75,0.75,1.0],to_color:[0.0,0.0,1.0],scale:2} ^ ^2 ^3 0 2 0 1 10 force
+execute as @e[limit=5,sort=random] rotated as @s rotated ~ 0 run particle minecraft:dust_color_transition{from_color:[0.75,0.75,1.0],to_color:[0.0,0.0,1.0],scale:2} ^ ^0.5 ^3 0 0 2 1 10 force

--- a/data/skill/function/act/black_mage/blitz_maneuver/act0.mcfunction
+++ b/data/skill/function/act/black_mage/blitz_maneuver/act0.mcfunction
@@ -1,0 +1,14 @@
+#> skill:act/black_mage/blitz_maneuver/act0
+#
+# ブリッツマニューバ発動
+
+# Lv2では2回トリガー
+execute if score _ Level matches 1 run scoreboard players set _ BlitzManeuver 100
+execute if score _ Level matches 2 run scoreboard players set _ BlitzManeuver 1200
+
+function skill:act/black_mage/blitz_maneuver/apply
+
+# スニーク中なら周囲のプレイヤーにも付与
+execute if score @s SneakTime matches 2 if score _ Level matches 1 run scoreboard players set _ BlitzManeuver 33
+execute if score @s SneakTime matches 2 if score _ Level matches 2 run scoreboard players set _ BlitzManeuver 1066
+execute if score @s SneakTime matches 2 as @a[distance=0.1..15] run function skill:act/black_mage/blitz_maneuver/apply

--- a/data/skill/function/act/black_mage/blitz_maneuver/apply.mcfunction
+++ b/data/skill/function/act/black_mage/blitz_maneuver/apply.mcfunction
@@ -1,0 +1,8 @@
+#> skill:act/black_mage/blitz_maneuver/apply
+#
+# ブリッツマニューバ適用
+scoreboard players operation @s BlitzManeuver = _ BlitzManeuver
+scoreboard players set @s Interval 0
+
+# 演出
+function makeup:skill/act/black_mage/blitz_maneuver/apply

--- a/data/skill/function/act/black_mage/blitz_maneuver/tick.mcfunction
+++ b/data/skill/function/act/black_mage/blitz_maneuver/tick.mcfunction
@@ -1,0 +1,13 @@
+#> skill:act/black_mage/blitz_maneuver/tick
+#
+# ブリッツマニューバ毎tick処理
+
+scoreboard players remove @s BlitzManeuver 1
+execute if score @s BlitzManeuver matches 900..1000 run scoreboard players set @s BlitzManeuver 0
+
+# execute unless score @s BlitzManeuver matches 0.. run tellraw @s [{"text":"","color":"yellow"},{"selector":"@s"},"の",{"text":"ブリッツマニューバ","color":"white","hoverEvent":{"action":"show_text","value":"次に使用するスキルの\nスキル使用不能時間を0にする。","color":"white"}},"の効果が切れた。"]
+execute unless score @s BlitzManeuver matches 0.. run tellraw @s [{"translate":"%1$sの%2$sの効果が切れた。","color":"yellow","with":[{"selector":"@s"},{"storage":"skill:","nbt":"Data.BlackMage[{Name:\"ブリッツマニューバ\",Level:1}].Name","hoverEvent":{"action":"show_text","contents":[{"storage":"skill:","nbt":"Data.BlackMage[{Name:\"ブリッツマニューバ\",Level:1}].Lore[]","interpret":true}]},"color":"white"}]}]
+execute unless score @s BlitzManeuver matches 0.. run scoreboard players reset @s BlitzManeuver
+
+# 演出
+function makeup:skill/act/black_mage/blitz_maneuver/tick

--- a/data/skill/function/act/black_mage/blitz_maneuver/trigger.mcfunction
+++ b/data/skill/function/act/black_mage/blitz_maneuver/trigger.mcfunction
@@ -1,0 +1,15 @@
+#> skill:act/black_mage/blitz_maneuver/trigger
+#
+# ブリッツマニューバトリガー
+#@Within function skill:practice/update_item
+execute store result score _ _ run data get storage item: Item.components."minecraft:custom_data".Skill.Interval
+execute store result score _ Calc run data get storage item: Item.components."minecraft:custom_data".Skil.LastUsed
+
+execute store result storage item: Item.components."minecraft:custom_data".Skill.LastUsed int 1 run scoreboard players operation _ _ += _ Calc
+data modify storage item: Item.components."minecraft:custom_data".Skill.ShowInterval set value 0b
+
+execute if score @s BlitzManeuver matches ..999 run scoreboard players set @s BlitzManeuver 0
+execute if score @s BlitzManeuver matches 1000.. run scoreboard players remove @s BlitzManeuver 1000
+
+# 演出
+function makeup:skill/act/black_mage/blitz_maneuver/trigger

--- a/data/skill/function/player_tick.mcfunction
+++ b/data/skill/function/player_tick.mcfunction
@@ -48,3 +48,7 @@ execute if entity @s[scores={RadarVision=1..}] run function skill:act/hunter/rad
 ## 白魔導士
 # ソルフレア
 execute if score @s SolFlareCharge matches 0.. run function skill:act/white_mage/sol_flare/tick
+
+## 黒魔導士
+# ブリッツマニューバ
+execute if entity @s[scores={BlitzManeuver=0..}] run function skill:act/black_mage/blitz_maneuver/tick

--- a/data/skill/function/practice/.mcfunction
+++ b/data/skill/function/practice/.mcfunction
@@ -9,7 +9,7 @@ execute store result score _ _ run data get storage skill: Skill.LastUsed
 execute store result score _ Interval run data get storage skill: Skill.Interval
 scoreboard players operation _ Calc -= _ _
 # ブリッツマニューバ - もしマイナスならインターバル無効
-execute if score @s BlitzManover matches 0.. if score _ Calc matches ..-1 run scoreboard players set _ Calc 0
+execute if score @s BlitzManeuver matches 0.. if score _ Calc matches ..-1 run scoreboard players set _ Calc 0
 scoreboard players operation _ Interval -= _ Calc
 # インターバル中
 execute if score _ Interval matches 1.. run return run function makeup:skill/practice/error/while_interval

--- a/data/skill/function/practice/update_item.mcfunction
+++ b/data/skill/function/practice/update_item.mcfunction
@@ -4,7 +4,7 @@ execute store result storage item: Item.components."minecraft:custom_data".Skill
 execute unless data storage item: Item.components."minecraft:custom_data".Skill{Interval:0} run data modify storage item: Item.components."minecraft:custom_data".Skill.ShowInterval set value 1b
 
 # ブリッツマニューバ - 付与直後は除外
-execute if score @s BlitzManover matches 0.. unless score @s BlitzManover matches 100 unless score @s BlitzManover matches 1200 run function skill:act/black_mage/blitz_manover/trigger
+execute if score @s BlitzManeuver matches 0.. unless score @s BlitzManeuver matches 100 unless score @s BlitzManeuver matches 1200 run function skill:act/black_mage/blitz_maneuver/trigger
 
 # アイテム更新
 execute in area:control_area run data modify block 2 2 2 Items set value []


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## チケット URL<!-- 必須 -->
<!-- GH-〇〇 チケット番号 -->
<!-- チケット番号がない場合は NO-ISSUE -->
GH-1025
## 対応内容・対応背景・妥協点<!-- 必須 -->
<!-- 簡単な説明 -->
<!-- スクリーンショットを添付してください -->
ブリッツマニューバを1.21.4に移植した。
## やったこと<!-- 必須 -->
<!-- このPR内でやったことを書く -->
manover(ドイツ語)→maneuver(英語)に綴りを変更（スプシは更新済み）
トリガー処理をアイテムコンポーネントに対応
dustをdust_color_translationに変更

## テスト<!-- なかったらこの項目を削除してください -->
<!-- テスト項目、テスト方法を書く -->
<!-- 例えばこのようにして確認したなどのスクリーンショットなど -->
・演出が違和感なく再現されている。
・別スキルのインターバルが正常に短縮された。
・Lv2では二回使えた。

<!-- ここから下は削除しないでください -->
### チェックリスト [(ガイドライン)](https://github.com/orgs/TUSB/discussions/1)
  - [ ] ガイドラインどおりですか? ([チェック表](https://github.com/orgs/TUSB/discussions/1#discussioncomment-12440295))
<!-- ここから上は削除しないでください -->
<!-- markdownlint-enable MD041 -->
